### PR TITLE
refactor: replace backend axios usage with fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6622,7 +6622,6 @@
       "version": "1.0.0",
       "dependencies": {
         "applicationinsights": "^2.9.5",
-        "axios": "^1.7.7",
         "cors": "^2.8.5",
         "dry-utils-async": "^0.3.0",
         "dry-utils-cosmosdb": "^0.3.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "applicationinsights": "^2.9.5",
-    "axios": "^1.7.7",
     "cors": "^2.8.5",
     "dry-utils-async": "^0.3.0",
     "dry-utils-cosmosdb": "^0.3.0",
@@ -23,7 +22,7 @@
     "@types/express": "^5.0.1",
     "@types/node": "^22.5.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.2",
-    "tsx": "^4.7.1"
+    "tsx": "^4.7.1",
+    "typescript": "^5.6.2"
   }
 }

--- a/packages/backend/src/ats/greenhouse.ts
+++ b/packages/backend/src/ats/greenhouse.ts
@@ -173,18 +173,18 @@ export class Greenhouse extends ATSBase {
   }
 
   private async fetchCompany(id: string): Promise<CompanyResult> {
-    return this.axiosCall<CompanyResult>("Company", id, "");
+    return this.httpCall<CompanyResult>("Company", id, "");
   }
 
   private async fetchJob(id: string, jobId: string): Promise<JobResult> {
-    return this.axiosCall<JobResult>("Job", id, `jobs/${jobId}`);
+    return this.httpCall<JobResult>("Job", id, `jobs/${jobId}`);
   }
 
   private async fetchJobs(id: string): Promise<JobsResult> {
-    return this.axiosCall<JobsResult>("Jobs", id, "/jobs?content=true");
+    return this.httpCall<JobsResult>("Jobs", id, "/jobs?content=true");
   }
 
   private async fetchJobsBasic(id: string): Promise<JobsResultBasic> {
-    return this.axiosCall<JobsResultBasic>("JobsBasic", id, "/jobs");
+    return this.httpCall<JobsResultBasic>("JobsBasic", id, "/jobs");
   }
 }

--- a/packages/backend/src/ats/lever.ts
+++ b/packages/backend/src/ats/lever.ts
@@ -167,6 +167,6 @@ export class Lever extends ATSBase {
 
   private async fetchJobs(id: string, single = false): Promise<JobResult[]> {
     const query = single ? "?mode=json&limit=1" : "?mode=json";
-    return this.axiosCall<JobResult[]>("Jobs", id, query);
+    return this.httpCall<JobResult[]>("Jobs", id, query);
   }
 }


### PR DESCRIPTION
## Summary
- replace the shared ATS HTTP helper to use the native fetch API instead of axios
- update Greenhouse and Lever integrations to call the new helper
- remove the axios dependency from the backend workspace

## Testing
- npm run build --workspace backend

------
https://chatgpt.com/codex/tasks/task_e_68e55b1422748333ab2c5a0c406c5051