### PR TITLE
Add admin CLI support for deleting jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "unlink-dry-utils": "npm unlink dry-utils-async dry-utils-text dry-utils-openai dry-utils-cosmosdb",
     "eval": "npm run eval --workspace=evals --",
     "eval-fetch-input": "npm run fetch-input --workspace=evals --",
-    "add-companies": "npm run add-companies --workspace=admin",
+    "admin": "npm run admin --workspace=admin",
     "clean": "git clean -fdx node_modules && git clean -fdx **/dist/ **/tsconfig.tsbuildinfo"
   },
   "private": true,

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -4,8 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "add-companies": "tsx --env-file=.env src/index.ts",
-    "delete-job": "tsx --env-file=.env src/index.ts delete-job"
+    "admin": "tsx --env-file=.env src/index.ts"
   },
   "devDependencies": {
     "@types/node": "^22.5.5",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "add-companies": "tsx --env-file=.env src/index.ts"
+    "add-companies": "tsx --env-file=.env src/index.ts",
+    "delete-job": "tsx --env-file=.env src/index.ts delete-job"
   },
   "devDependencies": {
     "@types/node": "^22.5.5",

--- a/packages/admin/src/commands.ts
+++ b/packages/admin/src/commands.ts
@@ -1,0 +1,30 @@
+import { fetcher } from "./fetcher.ts";
+import { atsTypes } from "./types.ts";
+
+export async function addCompanies(args: string[]): Promise<void> {
+  let [ats, ...companyIds] = args;
+  ats = ats?.toLowerCase() ?? "";
+  companyIds = companyIds
+    .map((id) => id.replace(",", "").trim())
+    .filter((id) => !!id.length);
+
+  if (!atsTypes.includes(ats) || !companyIds.length) {
+    throw new Error("Invalid arguments");
+  }
+
+  console.log(`Adding ${companyIds.length} companies from ${ats}`);
+  const result = await fetcher("companies", "PUT", { ats, ids: companyIds });
+  console.log("Success", result);
+}
+
+export async function deleteJob(args: string[]): Promise<void> {
+  const [companyId, id] = args;
+
+  if (!companyId || !id) {
+    throw new Error("Invalid arguments");
+  }
+
+  console.log(`Deleting job ${id} for company ${companyId}`);
+  const result = await fetcher("job", "DELETE", { id, companyId });
+  console.log("Success", result);
+}

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,73 +1,45 @@
 import process from "node:process";
-import { fetcher } from "./fetcher.ts";
-
-const atsTypes = ["greenhouse", "lever"];
+import { addCompanies, deleteJob } from "./commands.ts";
+import { atsTypes, commands } from "./types.ts";
 
 function usageReminder() {
   console.error(
     [
       "Usage:",
-      "  npm run add-companies -- <ATS_ID> <COMPANY_ID> [...COMPANY_ID]",
-      `    atsType: ${atsTypes.join("|")}`,
+      "  npm run admin -- <COMMAND> <ARGS>",
       "",
-      "  npm run delete-job -- <JOB_ID> <COMPANY_ID>",
+      `  COMMAND: ${commands.join("|")}`,
+      "",
+      "  npm run admin -- add-companies <ATS_ID> <COMPANY_ID> [...COMPANY_ID]",
+      `    ATS_ID: ${atsTypes.join("|")}`,
+      "",
+      "  npm run admin -- delete-job <COMPANY_ID> <JOB_ID>",
     ].join("\n")
   );
 }
 
-async function addCompanies(ats: string, ids: string[]): Promise<void> {
-  console.log(`Adding ${ids.length} companies from ${ats}`);
-  const result = await fetcher("companies", "PUT", { ats, ids });
-  console.log("Success", result);
-}
-
-async function deleteJob(jobId: string, companyId: string): Promise<void> {
-  console.log(`Deleting job ${jobId} for company ${companyId}`);
-  const result = await fetcher("job", "DELETE", {
-    id: jobId,
-    companyId,
-  });
-  console.log("Success", result);
-}
-
-async function handleAddCompanies(args: string[]): Promise<void> {
-  let [ats, ...companyIds] = args;
-  ats = ats?.toLowerCase() ?? "";
-  companyIds = companyIds
-    .map((id) => id.replace(",", "").trim())
-    .filter((id) => !!id.length);
-
-  if (!atsTypes.includes(ats) || !companyIds.length) {
-    usageReminder();
-    return;
-  }
-
-  await addCompanies(ats, companyIds);
-}
-
-async function handleDeleteJob(args: string[]): Promise<void> {
-  const [jobId, companyId] = args.map((value) => value?.trim() ?? "");
-
-  if (!jobId || !companyId) {
-    usageReminder();
-    return;
-  }
-
-  await deleteJob(jobId, companyId);
-}
-
 async function run() {
-  const args = process.argv.slice(2);
+  const [command, ...args] = process.argv.slice(2);
 
-  if (args[0]?.toLowerCase() === "delete-job") {
-    await handleDeleteJob(args.slice(1));
-    return;
+  switch (command) {
+    case "add-companies":
+      await addCompanies(args);
+      break;
+    case "delete-job":
+      await deleteJob(args);
+      break;
+    default:
+      throw new Error("Invalid command");
   }
-
-  await handleAddCompanies(args);
 }
 
 run().catch((err) => {
+  if (
+    err instanceof Error &&
+    ["Invalid command", "Invalid arguments"].includes(err.message)
+  ) {
+    usageReminder();
+  }
   console.error(err instanceof Error ? err.message : err);
   process.exitCode = 1;
 });

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -5,8 +5,13 @@ const atsTypes = ["greenhouse", "lever"];
 
 function usageReminder() {
   console.error(
-    "Usage: npm run add-companies -- <ATS_ID> <COMPANY_ID> [...COMPANY_ID]\n" +
-      `  atsType: ${atsTypes.join("|")}\n`
+    [
+      "Usage:",
+      "  npm run add-companies -- <ATS_ID> <COMPANY_ID> [...COMPANY_ID]",
+      `    atsType: ${atsTypes.join("|")}`,
+      "",
+      "  npm run delete-job -- <JOB_ID> <COMPANY_ID>",
+    ].join("\n")
   );
 }
 
@@ -16,8 +21,16 @@ async function addCompanies(ats: string, ids: string[]): Promise<void> {
   console.log("Success", result);
 }
 
-async function run() {
-  const args = process.argv.slice(2);
+async function deleteJob(jobId: string, companyId: string): Promise<void> {
+  console.log(`Deleting job ${jobId} for company ${companyId}`);
+  const result = await fetcher("job", "DELETE", {
+    id: jobId,
+    companyId,
+  });
+  console.log("Success", result);
+}
+
+async function handleAddCompanies(args: string[]): Promise<void> {
   let [ats, ...companyIds] = args;
   ats = ats?.toLowerCase() ?? "";
   companyIds = companyIds
@@ -30,6 +43,28 @@ async function run() {
   }
 
   await addCompanies(ats, companyIds);
+}
+
+async function handleDeleteJob(args: string[]): Promise<void> {
+  const [jobId, companyId] = args.map((value) => value?.trim() ?? "");
+
+  if (!jobId || !companyId) {
+    usageReminder();
+    return;
+  }
+
+  await deleteJob(jobId, companyId);
+}
+
+async function run() {
+  const args = process.argv.slice(2);
+
+  if (args[0]?.toLowerCase() === "delete-job") {
+    await handleDeleteJob(args.slice(1));
+    return;
+  }
+
+  await handleAddCompanies(args);
 }
 
 run().catch((err) => {

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -1,0 +1,2 @@
+export const commands = ["add-companies", "delete-job"];
+export const atsTypes = ["greenhouse", "lever"];


### PR DESCRIPTION
## Summary
- add a delete-job command to the admin script and reuse the existing entrypoint
- update usage guidance so operators know how to call each command

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e55ba35e608333a033c12680d4872e