### PR TITLE
Add metadataModel frontend unit tests

### DIFF
--- a/packages/frontend/src/api/metadataModel.test.ts
+++ b/packages/frontend/src/api/metadataModel.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, expect, suite, test, vi } from "vitest";
+import type { MetadataModelApi } from "./apiTypes";
+
+const fetchMetadata = vi.fn<() => Promise<MetadataModelApi>>();
+
+vi.mock("./api", () => ({
+  api: {
+    fetchMetadata,
+  },
+}));
+
+function createMetadata(
+  overrides: Partial<MetadataModelApi> = {},
+): MetadataModelApi {
+  return {
+    companyCount: 2,
+    companyNames: [
+      ["company-b", "Beta Corp"],
+      ["company-a", "Alpha Co"],
+    ],
+    jobCount: 1234,
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+async function loadMetadataModel() {
+  const { metadataModel } = await import("./metadataModel");
+  return metadataModel;
+}
+
+suite("metadataModel", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    fetchMetadata.mockReset();
+  });
+
+  test("formats the metadata timestamp for display", async () => {
+    fetchMetadata.mockResolvedValue(createMetadata());
+
+    const toLocaleString = vi
+      .spyOn(Date.prototype, "toLocaleString")
+      .mockReturnValue("Nov 14, 2023, 10:13 AM");
+
+    const metadataModel = await loadMetadataModel();
+
+    await expect(metadataModel.getTimestampString()).resolves.toBe(
+      "Nov 14, 2023, 10:13 AM",
+    );
+    expect(fetchMetadata).toHaveBeenCalledTimes(1);
+    expect(toLocaleString).toHaveBeenCalledTimes(1);
+  });
+
+  test("formats job and company counts for display", async () => {
+    fetchMetadata.mockResolvedValue(
+      createMetadata({ jobCount: 1234567, companyCount: 8901 }),
+    );
+
+    const toLocaleString = vi
+      .spyOn(Number.prototype, "toLocaleString")
+      .mockReturnValueOnce("1,234,567")
+      .mockReturnValueOnce("8,901");
+
+    const metadataModel = await loadMetadataModel();
+
+    await expect(metadataModel.getCountStrings()).resolves.toEqual({
+      jobCount: "1,234,567",
+      companyCount: "8,901",
+    });
+    expect(fetchMetadata).toHaveBeenCalledTimes(1);
+    expect(toLocaleString).toHaveBeenCalledTimes(2);
+  });
+
+  test("maps company names into sorted form options", async () => {
+    fetchMetadata.mockResolvedValue(createMetadata());
+
+    const metadataModel = await loadMetadataModel();
+
+    await expect(metadataModel.getCompanyFormOptions()).resolves.toEqual([
+      { value: "company-a", label: "Alpha Co" },
+      { value: "company-b", label: "Beta Corp" },
+    ]);
+  });
+
+  test("stores company friendly names after a metadata fetch", async () => {
+    fetchMetadata.mockResolvedValue(createMetadata());
+
+    const metadataModel = await loadMetadataModel();
+
+    expect(metadataModel.getCompanyFriendlyName("company-a")).toBeUndefined();
+
+    await metadataModel.getCompanyFormOptions();
+
+    expect(metadataModel.getCompanyFriendlyName("company-a")).toBe("Alpha Co");
+    expect(
+      metadataModel.getCompanyFriendlyName("missing-company"),
+    ).toBeUndefined();
+  });
+
+  test("keeps the existing company name map when the company count is unchanged", async () => {
+    fetchMetadata.mockResolvedValueOnce(createMetadata()).mockResolvedValueOnce(
+      createMetadata({
+        companyNames: [
+          ["company-b", "Beta Labs"],
+          ["company-a", "Acme Co"],
+        ],
+      }),
+    );
+
+    const metadataModel = await loadMetadataModel();
+
+    await metadataModel.getCompanyFormOptions();
+    await metadataModel.getCountStrings();
+
+    expect(metadataModel.getCompanyFriendlyName("company-a")).toBe("Alpha Co");
+    expect(metadataModel.getCompanyFriendlyName("company-b")).toBe("Beta Corp");
+  });
+
+  test("refreshes the cached company name map when the company count changes", async () => {
+    fetchMetadata
+      .mockResolvedValueOnce(
+        createMetadata({
+          companyCount: 1,
+          companyNames: [["company-a", "Alpha Co"]],
+        }),
+      )
+      .mockResolvedValueOnce(
+        createMetadata({
+          companyCount: 2,
+          companyNames: [
+            ["company-a", "Acme Co"],
+            ["company-c", "Charlie LLC"],
+          ],
+        }),
+      );
+
+    const metadataModel = await loadMetadataModel();
+
+    await metadataModel.getCompanyFormOptions();
+    expect(metadataModel.getCompanyFriendlyName("company-a")).toBe("Alpha Co");
+
+    await metadataModel.getTimestampString();
+
+    expect(metadataModel.getCompanyFriendlyName("company-a")).toBe("Acme Co");
+    expect(metadataModel.getCompanyFriendlyName("company-c")).toBe(
+      "Charlie LLC",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide thorough unit coverage for the frontend `metadataModel` to prevent regressions in metadata formatting and cache behavior.

### Description
- Add a new `packages/frontend/src/api/metadataModel.test.ts` test suite that mocks the API dependency via `vi.mock("./api")` and isolates the singleton by resetting modules between tests.
- Test timestamp formatting via `getTimestampString`, localized number formatting via `getCountStrings`, and sorted company form options via `getCompanyFormOptions`.
- Verify friendly-name lookup through `getCompanyFriendlyName` and exercise cache semantics to ensure the internal company-name map is preserved when `companyCount` is unchanged and refreshed when it changes.
- Use local helpers (`createMetadata` and `loadMetadataModel`) and `vitest` mocks/spies to keep tests deterministic and compact.

### Testing
- Ran the targeted frontend tests with `npm run test --workspace=frontend -- metadataModel.test.ts`, and all tests passed (6 tests passed in that file).
- Ran repository quality checks with `npm run pre-checkin` which includes linting, formatting, and the full test matrix, and the run completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a0f9afc083339006b8cb7442f138)