### PR TITLE
E2e updates

### DIFF
--- a/packages/cli/.env.example
+++ b/packages/cli/.env.example
@@ -28,14 +28,11 @@ OPENAI_API_KEY=unset
 
 # =============================================================================
 # E2E test fixtures — optional; required to run e2e tests.
-# Prefer companies with 3–5 jobs each.
+# Format: pipe-separated `ats:id1,id2` entries. Prefer companies with 3–5 jobs each.
+# Example: greenhouse:company-a,company-b|lever:company-c
 # =============================================================================
 
-# Comma-separated Greenhouse company IDs for e2e tests.
-# GREENHOUSE_IDS=
-
-# Comma-separated Lever company IDs for e2e tests.
-# LEVER_IDS=
+# E2E_COMPANIES=
 
 # =============================================================================
 # Backend - See packages/backend/.env.example for more options

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -65,7 +65,7 @@ npm run cli -- ats exactJob lever my-company-slug abc-123
 ### `e2e` — Run end-to-end tests
 
 Runs a predefined flow of API calls against the local backend and asserts expected responses.
-Requires a running local server and `GREENHOUSE_IDS`/`LEVER_IDS` to be populated.
+Requires a running local server and `E2E_COMPANIES` to be populated.
 
 ```bash
 npm run cli -- e2e <FLOW>

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,3 +1,5 @@
+import { atsTypes, type ATS } from "./portal/atsConsts.ts";
+
 interface Config {
   // API configs
   API_URL: string;
@@ -7,8 +9,7 @@ interface Config {
   PROD_ADMIN_TOKEN?: string;
 
   // E2E test configs
-  GREENHOUSE_IDS: string[];
-  LEVER_IDS: string[];
+  E2E_COMPANIES: Partial<Record<ATS, string[]>>;
 }
 type KEY = keyof Config;
 
@@ -36,6 +37,26 @@ const toArr = (s: string = "") =>
     .filter(Boolean);
 
 /**
+ * Parses a `|`-delimited list of `ats:id1,id2` entries into a record.
+ * Example: `greenhouse:id1,id2|lever:id3,id4`
+ */
+const toCompanies = (s: string = ""): Partial<Record<ATS, string[]>> => {
+  if (!s) return {};
+  return Object.fromEntries(
+    s.split("|").map((entry) => {
+      const [ats = "", ids = ""] = entry.split(":");
+      const trimmed = ats.trim();
+      if (!atsTypes.includes(trimmed as ATS)) {
+        throw new Error(
+          `E2E_COMPANIES: unknown ATS "${trimmed}". Expected one of: ${atsTypes.join(", ")}`,
+        );
+      }
+      return [trimmed as ATS, toArr(ids)];
+    }),
+  );
+};
+
+/**
  * CLI configuration derived from environment variables.
  */
 export const config: Config = {
@@ -45,6 +66,5 @@ export const config: Config = {
   PROD_API_URL: normUrl(getReqEnv("PROD_API_URL")),
   PROD_ADMIN_TOKEN: getEnv("PROD_ADMIN_TOKEN"),
 
-  GREENHOUSE_IDS: toArr(getEnv("GREENHOUSE_IDS")),
-  LEVER_IDS: toArr(getEnv("LEVER_IDS")),
+  E2E_COMPANIES: toCompanies(getEnv("E2E_COMPANIES")),
 };

--- a/packages/cli/src/e2e/commands.ts
+++ b/packages/cli/src/e2e/commands.ts
@@ -1,12 +1,10 @@
 import { logger } from "dry-utils-logger";
 import assert from "node:assert/strict";
-import { config } from "../config.ts";
 import { CommandError, type Command } from "../types.ts";
 import { apiCall } from "../utils/http.ts";
 import { flows } from "./flows.ts";
 import type { Step } from "./step.ts";
 
-const { GREENHOUSE_IDS, LEVER_IDS } = config;
 const FLOW_NAMES = Object.keys(flows);
 
 export const e2e: Command = {
@@ -15,7 +13,6 @@ export const e2e: Command = {
     "Run the e2e tests against a running local server",
     `FLOW: ${FLOW_NAMES.join("|")}`,
   ],
-  prerequisite,
   run: async ([flow]: string[]): Promise<void> => {
     if (!flow || !FLOW_NAMES.includes(flow)) {
       throw new CommandError("Invalid argument: FLOW");
@@ -24,11 +21,6 @@ export const e2e: Command = {
     await runFlow(flow);
   },
 };
-
-function prerequisite(): void {
-  assert.ok(GREENHOUSE_IDS.length > 2, "ENV: GREENHOUSE_IDS <= 2");
-  assert.ok(LEVER_IDS.length > 2, "ENV: LEVER_IDS <= 2");
-}
 
 /**
  * Execute the named flow against the configured backend API.

--- a/packages/cli/src/e2e/commands.ts
+++ b/packages/cli/src/e2e/commands.ts
@@ -41,7 +41,11 @@ async function runFlow(name: string): Promise<void> {
     }
   } catch (err) {
     if (err instanceof assert.AssertionError) {
-      logger.error("Assertion Error", err.message);
+      logger.error("Assertion Error", {
+        message: err.message.split("\n")[0],
+        expected: err.expected,
+        actual: err.actual,
+      });
       return;
     }
     throw err;

--- a/packages/cli/src/e2e/commands.ts
+++ b/packages/cli/src/e2e/commands.ts
@@ -57,8 +57,9 @@ async function runFlow(name: string): Promise<void> {
 async function runStep(
   n: number,
   total: number,
-  { name, method, path, expectStatus, expectBody, asyncWait, ...opts }: Step,
+  { name, req, res, confirm }: Step,
 ): Promise<void> {
+  const { method, path, ...opts } = req;
   logger.info(`[${n}/${total}] ${method} ${path}: ${name}`);
 
   const { status, value } = await apiCall(method, path, {
@@ -69,17 +70,17 @@ async function runStep(
 
   logger.info(`[${status}]`, value);
 
-  assert.equal(status, expectStatus, `FAIL: Step ${n} Wrong Status`);
-  if (expectBody != undefined) {
+  assert.equal(status, res.status, `FAIL: Step ${n} Wrong Status`);
+  if (res.value != undefined) {
     assert.partialDeepStrictEqual(
       value,
-      expectBody,
+      res.value,
       `FAIL: Step ${n} Wrong Body`,
     );
   }
 
-  if (asyncWait) {
-    logger.info(`${asyncWait}, then press Enter to continue...`);
+  if (confirm) {
+    logger.info(`${confirm}, then press Enter to continue...`);
     await new Promise<void>((resolve) => {
       // When you attach a data listener to process.stdin, it switches the stream into "flowing" mode.
       // To allow the script to exit, you need to explicitly pause() the stdin stream after receiving the data.

--- a/packages/cli/src/e2e/flows.ts
+++ b/packages/cli/src/e2e/flows.ts
@@ -1,223 +1,168 @@
-import { config } from "../config.ts";
+import { atsTypes } from "../portal/atsConsts.ts";
 import {
   type Step,
-  addCompaniesStep,
-  addCompanyStep,
-  delCompanyStep,
-  formAsyncStep,
-  formErrStep,
+  allAddAts,
+  allDelAts,
+  ats,
+  companyId,
+  companyIds,
   formStep,
-  formSucStep,
-  resetSteps,
+  oneAddEachAts,
+  req,
+  res,
 } from "./step.ts";
 
-const { GREENHOUSE_IDS: ghIds, LEVER_IDS: lvIds } = config;
-
-const UNKNOWN = "unknown_id";
+const unknown = "unknown_id";
+const UNDEFINED_ID =
+  "id field is invalid: Invalid input: expected string, received undefined";
 
 const pings: Step[] = [
-  formSucStep("", "Ping"),
-  formStep("unknown", "404", { expectStatus: 404, expectBody: "Not Found" }),
-  formStep("jobs", "Empty Query", { expectBody: [] }),
-  formStep("metadata", "Status check", { expectBody: {} }),
+  formStep("Ping", req.get(""), res.ok({ status: "success" })),
+  formStep("404", req.get("unknown"), res(404, "Not Found")),
+  formStep("Empty query", req.get("jobs"), res.ok([])),
+  formStep("Status check", req.get("metadata"), res.ok({})),
 ];
 
 const validations: Step[] = [
   // Refresh Jobs
-  formErrStep("refresh/jobs", "Auth Missing", "Unauthorized", {
-    method: "POST",
-    expectStatus: 401,
-  }),
-  formErrStep(
-    "refresh/jobs",
+  formStep(
+    "Auth Missing",
+    req.post("refresh/jobs", { asAdmin: false }),
+    res.err("Unauthorized", 401),
+  ),
+  formStep(
     "Unknown Arg Error",
-    'Unrecognized key: "unknownArg"',
-    {
-      method: "POST",
-      asAdmin: true,
-      body: {
-        ats: "greenhouse",
-        companyId: ghIds[0],
-        unknownArg: UNKNOWN,
-      },
-    },
+    req.post("refresh/jobs", { body: { ats, companyIds, unknown } }),
+    res.err('Unrecognized key: "unknown"'),
   ),
-  formErrStep(
-    "refresh/jobs",
+  formStep(
     "Company without ATS Error",
-    "ats field is required when using companyId",
-    {
-      method: "POST",
-      asAdmin: true,
-      body: {
-        companyId: ghIds[0],
-      },
-    },
+    req.post("refresh/jobs", { body: { companyIds } }),
+    res.err("ats field is required when using companyIds"),
   ),
-  formErrStep(
-    "refresh/jobs",
+  formStep(
     "Unknown ATS Error",
-    'ats field is invalid: Invalid option: expected one of "ashby"|"greenhouse"|"lever"',
-    {
-      method: "POST",
-      asAdmin: true,
-      body: {
-        ats: UNKNOWN,
-        companyId: ghIds[0],
-      },
-    },
+    req.post("refresh/jobs", { body: { ats: unknown, companyIds } }),
+    res.err(
+      `ats field is invalid: Invalid option: expected one of ${atsTypes.map((type) => `"${type}"`).join("|")}`,
+    ),
   ),
 
   // Company
-  formErrStep(
-    "company",
+  formStep(
     "Empty Body Error",
-    "id field is invalid: Invalid input: expected string, received undefined",
-    {
-      method: "PUT",
-      body: {},
-    },
+    req.put("company", { asAdmin: false, body: {} }),
+    res.err(UNDEFINED_ID),
   ),
-  formErrStep(
-    "companies",
+  formStep(
     "Empty Body Error",
-    "ids field is invalid: Invalid input: expected array, received undefined",
-    {
-      method: "PUT",
-      asAdmin: true,
-      body: {},
-    },
+    req.put("companies", { body: {} }),
+    res.err(
+      "ids field is invalid: Invalid input: expected array, received undefined",
+    ),
   ),
-  formErrStep(
-    "companies",
+  formStep(
     "Empty IDs Error",
-    "ids field is invalid: Too small: expected array to have >=1 items",
-    {
-      method: "PUT",
-      asAdmin: true,
-      body: { ats: "greenhouse", ids: [] },
-    },
+    req.put("companies", { body: { ats: "greenhouse", ids: [] } }),
+    res.err(
+      "ids field is invalid: Too small: expected array to have >=1 items",
+    ),
   ),
-  formErrStep(
-    "company",
+  formStep(
     "Empty Body Error",
-    "id field is invalid: Invalid input: expected string, received undefined",
-    {
-      method: "DELETE",
-      asAdmin: true,
-      body: {},
-    },
+    req.del("company", { body: {} }),
+    res.err(UNDEFINED_ID),
   ),
 
   // Job
-  formErrStep(
-    "job/apply",
-    "Missing Query Error",
-    "id field is invalid: Invalid input: expected string, received undefined",
-    {},
+  formStep("Missing Query Error", req.get("job/apply"), res.err(UNDEFINED_ID)),
+  formStep(
+    "Not Found Error",
+    req.get("job/apply", {
+      query: {
+        id: unknown,
+        companyId: unknown,
+      },
+    }),
+    res.err("Job not found", 404),
   ),
-  formErrStep("job/apply", "Not Found Error", "Job not found", {
-    query: {
-      id: UNKNOWN,
-      companyId: UNKNOWN,
-    },
-    expectStatus: 404,
-  }),
-  formErrStep(
-    "company/job",
+  formStep(
     "Empty Body Error",
-    "companyId field is invalid: Invalid input: expected string, received undefined",
-    {
-      method: "DELETE",
-      asAdmin: true,
-      body: {},
-    },
+    req.del("company/job", { body: {} }),
+    res.err(
+      "companyId field is invalid: Invalid input: expected string, received undefined",
+    ),
   ),
 ];
 
 const unknowns: Step[] = [
-  formAsyncStep("refresh/jobs", "Unknown Company", {
-    body: {
-      ats: "greenhouse",
-      companyId: UNKNOWN,
-    },
-  }),
-  formErrStep(
-    "company",
+  formStep(
     "Unknown Company",
-    `greenhouse / ${UNKNOWN}: Not Found`,
-    {
-      method: "PUT",
+    req.post("refresh/jobs", { body: { ats, companyIds: [unknown] } }),
+    res.accepted,
+    "Verify internal Not Found exception",
+  ),
+  formStep(
+    "Unknown Company",
+    req.put("company", { asAdmin: false, body: { ats, id: unknown } }),
+    res.err(`greenhouse / ${unknown}: Not Found`, 404),
+  ),
+  formStep(
+    "Unknown Companies",
+    req.put("companies", {
       body: {
         ats: "greenhouse",
-        id: UNKNOWN,
+        ids: [unknown, unknown + "2", unknown + "3"],
       },
-      expectStatus: 404,
-    },
-  ),
-  addCompaniesStep(
-    "greenhouse",
-    [UNKNOWN, UNKNOWN + "2", UNKNOWN + "3"],
+    }),
+    res.ok(),
     "Verify internal Not Found exceptions",
   ),
-  delCompanyStep("greenhouse", UNKNOWN),
-  formSucStep("company/job", "Unknown Company", {
-    method: "DELETE",
-    asAdmin: true,
-    body: {
-      ats: "greenhouse",
-      jobId: UNKNOWN,
-      companyId: UNKNOWN,
-    },
-  }),
-  formSucStep("company/job", "Unknown Job", {
-    method: "DELETE",
-    asAdmin: true,
-    body: {
-      ats: "greenhouse",
-      jobId: UNKNOWN,
-      companyId: ghIds[0],
-    },
-  }),
+  formStep(
+    "Unknown Company",
+    req.del("company", { body: { ats, id: unknown } }),
+    res.ok(),
+  ),
+  formStep(
+    "Unknown Company",
+    req.del("company/job", {
+      body: { ats, companyId: unknown, jobId: unknown },
+    }),
+    res.ok(),
+  ),
+  formStep(
+    "Unknown Job",
+    req.del("company/job", { body: { ats, companyId, jobId: unknown } }),
+    res.ok(),
+  ),
 ];
 
 const companies: Step[] = [
-  ...resetSteps,
-  // Metadata baseline would go here
-  // Add one company from each ATS
-  addCompanyStep("greenhouse", ghIds[0]!),
-  addCompanyStep("lever", lvIds[0]!),
+  ...allDelAts,
+  ...oneAddEachAts,
   // Re-add the same companies to test idempotency
-  addCompanyStep("greenhouse", ghIds[0]!),
-  addCompanyStep("lever", lvIds[0]!),
-  // Add multiple companies from each ATS
-  addCompaniesStep("greenhouse", ghIds),
-  addCompaniesStep("lever", lvIds, "Verify RefreshCompanyInfo actions"),
-  // Metadata check would go here
-  formAsyncStep("refresh/companies", "Refresh All Companies"),
-  // Metadata check would go here
+  ...oneAddEachAts,
+  ...allAddAts,
+
+  formStep(
+    "Refresh All Companies",
+    req.post("refresh/companies"),
+    res.accepted,
+    "Verify Company Refreshes",
+  ),
 ];
 
 const manual = [
-  //addCompanyStep("greenhouse", "noxgroup"),
-  formSucStep("refresh/jobs", "Refresh Company", {
-    method: "POST",
-    asAdmin: true,
-    body: {
-      ats: "greenhouse",
-      companyId: "propublica",
-      //replaceJobsOlderThan: Date.now() - 1000 * 60 * 60 * 24 * 90, // 90 days
-    },
-  }),
-  /*formSucStep("company/job", "Ignore Job", {
-    method: "DELETE",
-    asAdmin: true,
-    body: {
-      ats: "greenhouse",
-      companyId: "propublica",
-      jobId: "4053828006",
-    },
-  }),*/
+  formStep(
+    "Refresh Jobs for Company",
+    req.post("refresh/jobs", {
+      body: {
+        ats: "greenhouse",
+        companyIds: ["propublica"],
+      },
+    }),
+    res.accepted,
+  ),
 ];
 
 /*

--- a/packages/cli/src/e2e/step.ts
+++ b/packages/cli/src/e2e/step.ts
@@ -1,115 +1,118 @@
 import { config } from "../config.ts";
-import type { ATS } from "../portal/atsConsts.ts";
+import { atsTypes, type ATS } from "../portal/atsConsts.ts";
 import type { HttpMethod } from "../types.ts";
 
 const { GREENHOUSE_IDS: ghIds, LEVER_IDS: lvIds } = config;
-const SUCCESS_BODY = { status: "success" };
+
+const atsMap: Record<ATS, string[]> = {
+  greenhouse: ghIds,
+  lever: lvIds,
+  ashby: [],
+};
+export const ats = "greenhouse" as const;
+export const companyId = atsMap[ats][0];
+export const companyIds = atsMap[ats];
+
+// #region Request
+
+interface ReqOpts {
+  asAdmin?: boolean;
+  query?: Record<string, string>;
+  body?: unknown;
+}
+
+interface Req extends ReqOpts {
+  method: HttpMethod;
+  path: string;
+}
+
+export const req = (
+  method: HttpMethod,
+  path: string,
+  opts: ReqOpts,
+  asAdmin: boolean,
+): Req => ({ method, path, asAdmin, ...opts });
+
+req.get = (path: string, opts: ReqOpts = {}): Req =>
+  req("GET", path, opts, false);
+req.post = (path: string, opts: ReqOpts = {}): Req =>
+  req("POST", path, opts, true);
+req.put = (path: string, opts: ReqOpts = {}): Req =>
+  req("PUT", path, opts, true);
+req.del = (path: string, opts: ReqOpts = {}): Req =>
+  req("DELETE", path, opts, true);
+
+// #endregion
+
+// #region Results
+
+interface Res {
+  status: number;
+  value?: unknown;
+}
+
+export const res = (status: number, value?: unknown): Res => ({
+  status,
+  value,
+});
+res.ok = (value?: unknown): Res => res(200, value);
+res.err = (message: string, status = 400): Res =>
+  res(status, { status: "error", statusCode: status, message });
+res.accepted = res(202, "Accepted");
+
+// #endregion
+
+/// #region Step
 
 /**
  * Defines a single step in an end-to-end flow.
  */
 export interface Step {
   name: string;
-
-  // Request
-  method: HttpMethod;
-  path: string;
-  asAdmin: boolean;
-  query?: Record<string, string>;
-  body?: unknown;
-
-  // Expected Response
-  expectStatus: number;
-  expectBody?: unknown;
-
-  // Wait on user input before proceeding
-  asyncWait?: string;
+  req: Req;
+  res: Res;
+  // Display this message and wait on user input before proceeding
+  confirm?: string;
 }
 
 export const formStep = (
-  path: string,
   name: string,
-  step: Partial<Step> = {},
-): Step => ({
-  name,
-  path,
-  method: "GET",
-  asAdmin: false,
-  expectStatus: 200,
-  ...step,
-});
+  req: Req,
+  res: Res,
+  confirm?: string,
+): Step => ({ name, req, res, confirm });
 
-export const formSucStep = (
-  path: string,
-  name: string,
-  step: Partial<Step> = {},
-): Step => formStep(path, name, { expectBody: SUCCESS_BODY, ...step });
+export const oneAddEachAts = atsTypes.map((ats) =>
+  formStep(
+    `Add ${ats} company`,
+    req.put("company", { asAdmin: false, body: { ats, id: atsMap[ats][0] } }),
+    res.ok(),
+  ),
+);
 
-export const formAsyncStep = (
-  path: string,
-  name: string,
-  step: Partial<Step> = {},
-): Step =>
-  formStep(path, name, {
-    method: "POST",
-    asAdmin: true,
-    expectStatus: 202,
-    expectBody: "Accepted",
-    asyncWait: "Verify Async Action",
-    ...step,
-  });
+export const allAddAts = atsTypes.map((ats) =>
+  formStep(
+    `Add all ${ats} companies`,
+    req.put("companies", {
+      body: { ats, ids: atsMap[ats] },
+    }),
+    res.ok(),
+    `Verify ${ats} companies added`,
+  ),
+);
 
-export const formErrStep = (
-  path: string,
-  name: string,
-  message: string,
-  step: Partial<Step> = {},
-): Step =>
-  formStep(path, name, {
-    expectStatus: 400,
-    expectBody: errBody(message, step.expectStatus),
-    ...step,
-  });
-
-export const delCompanyStep = (ats: ATS, id: string): Step =>
-  companySucStep("DELETE", ats, id);
-
-export const addCompanyStep = (ats: ATS, id: string): Step =>
-  companySucStep("PUT", ats, id);
-
-export const addCompaniesStep = (
-  ats: ATS,
-  ids: string[],
-  asyncWait?: string,
-): Step =>
-  formSucStep("companies", `${ats} / [${ids.join(", ")}]`, {
-    method: "PUT",
-    asAdmin: true,
-    body: { ats, ids },
-    asyncWait,
-  });
-
-export const resetSteps: Step[] = [
-  ...ghIds.map((x) => delCompanyStep("greenhouse", x)),
-  ...lvIds.map((x) => delCompanyStep("lever", x)),
-];
-const lastStep = resetSteps.at(-1);
-if (lastStep) {
-  lastStep.asyncWait = "Verify companies deleted and metadata reset";
+export const allDelAts = atsTypes.flatMap((ats) =>
+  atsMap[ats].map((id) =>
+    formStep(
+      `Delete ${ats} company ${id}`,
+      req.del("company", { body: { ats, id } }),
+      res.ok(),
+    ),
+  ),
+);
+const lastDelStep = allDelAts.at(-1);
+if (lastDelStep) {
+  lastDelStep.confirm = "Verify companies deleted";
 }
 
-function companySucStep(method: HttpMethod, ats: ATS, id: string): Step {
-  return formSucStep(`company`, `${ats} / ${id}`, {
-    method,
-    asAdmin: true,
-    body: { ats, id },
-  });
-}
-
-function errBody(message: string, statusCode = 400) {
-  return {
-    status: "error",
-    statusCode,
-    message,
-  };
-}
+// #endregion

--- a/packages/cli/src/e2e/step.ts
+++ b/packages/cli/src/e2e/step.ts
@@ -47,7 +47,7 @@ req.del = (path: string, opts: ReqOpts = {}): Req =>
 
 // #endregion
 
-// #region Results
+// #region Response
 
 interface Res {
   status: number;
@@ -65,7 +65,7 @@ res.accepted = res(202, "Accepted");
 
 // #endregion
 
-/// #region Step
+// #region Step
 
 /**
  * Defines a single step in an end-to-end flow.
@@ -104,15 +104,14 @@ export const allAddAts = atsTypes.map((ats) =>
   ),
 );
 
-export const allDelAts = atsTypes.flatMap(
-  (ats) =>
-    getIds(ats).map((id) =>
-      formStep(
-        `Delete ${ats} company ${id}`,
-        req.del("company", { body: { ats, id } }),
-        res.ok(),
-      ),
-    ) ?? [],
+export const allDelAts = atsTypes.flatMap((ats) =>
+  getIds(ats).map((id) =>
+    formStep(
+      `Delete ${ats} company ${id}`,
+      req.del("company", { body: { ats, id } }),
+      res.ok(),
+    ),
+  ),
 );
 const lastDelStep = allDelAts.at(-1);
 if (lastDelStep) {

--- a/packages/cli/src/e2e/step.ts
+++ b/packages/cli/src/e2e/step.ts
@@ -2,16 +2,19 @@ import { config } from "../config.ts";
 import { atsTypes, type ATS } from "../portal/atsConsts.ts";
 import type { HttpMethod } from "../types.ts";
 
-const { GREENHOUSE_IDS: ghIds, LEVER_IDS: lvIds } = config;
-
-const atsMap: Record<ATS, string[]> = {
-  greenhouse: ghIds,
-  lever: lvIds,
-  ashby: [],
+const { E2E_COMPANIES } = config;
+const getIds = (ats: ATS): string[] => {
+  const ids = E2E_COMPANIES[ats] ?? [];
+  if (!ids.length) {
+    throw new Error(`Config E2E_COMPANIES: no IDs found for ATS "${ats}"`);
+  }
+  return ids;
 };
+const firstId = (ats: ATS): string => getIds(ats)[0]!;
+
 export const ats = "greenhouse" as const;
-export const companyId = atsMap[ats][0];
-export const companyIds = atsMap[ats];
+export const companyIds = getIds(ats);
+export const companyId = firstId(ats);
 
 // #region Request
 
@@ -85,7 +88,7 @@ export const formStep = (
 export const oneAddEachAts = atsTypes.map((ats) =>
   formStep(
     `Add ${ats} company`,
-    req.put("company", { asAdmin: false, body: { ats, id: atsMap[ats][0] } }),
+    req.put("company", { asAdmin: false, body: { ats, id: firstId(ats) } }),
     res.ok(),
   ),
 );
@@ -94,21 +97,22 @@ export const allAddAts = atsTypes.map((ats) =>
   formStep(
     `Add all ${ats} companies`,
     req.put("companies", {
-      body: { ats, ids: atsMap[ats] },
+      body: { ats, ids: getIds(ats) },
     }),
     res.ok(),
     `Verify ${ats} companies added`,
   ),
 );
 
-export const allDelAts = atsTypes.flatMap((ats) =>
-  atsMap[ats].map((id) =>
-    formStep(
-      `Delete ${ats} company ${id}`,
-      req.del("company", { body: { ats, id } }),
-      res.ok(),
-    ),
-  ),
+export const allDelAts = atsTypes.flatMap(
+  (ats) =>
+    getIds(ats).map((id) =>
+      formStep(
+        `Delete ${ats} company ${id}`,
+        req.del("company", { body: { ats, id } }),
+        res.ok(),
+      ),
+    ) ?? [],
 );
 const lastDelStep = allDelAts.at(-1);
 if (lastDelStep) {

--- a/packages/cli/src/e2e/step.ts
+++ b/packages/cli/src/e2e/step.ts
@@ -1,5 +1,5 @@
 import { config } from "../config.ts";
-import type { ATS } from "../portal/pTypes.ts";
+import type { ATS } from "../portal/atsConsts.ts";
 import type { HttpMethod } from "../types.ts";
 
 const { GREENHOUSE_IDS: ghIds, LEVER_IDS: lvIds } = config;

--- a/packages/cli/src/e2e/step.ts
+++ b/packages/cli/src/e2e/step.ts
@@ -3,14 +3,11 @@ import { atsTypes, type ATS } from "../portal/atsConsts.ts";
 import type { HttpMethod } from "../types.ts";
 
 const { E2E_COMPANIES } = config;
-const getIds = (ats: ATS): string[] => {
-  const ids = E2E_COMPANIES[ats] ?? [];
-  if (!ids.length) {
-    throw new Error(`Config E2E_COMPANIES: no IDs found for ATS "${ats}"`);
-  }
-  return ids;
-};
-const firstId = (ats: ATS): string => getIds(ats)[0]!;
+const configErrMsg = (ats: ATS) =>
+  `Config E2E_COMPANIES: no IDs found for ATS "${ats}"`;
+const getIds = (ats: ATS): string[] =>
+  E2E_COMPANIES[ats] ?? [configErrMsg(ats)];
+const firstId = (ats: ATS): string => getIds(ats)[0] ?? configErrMsg(ats);
 
 export const ats = "greenhouse" as const;
 export const companyIds = getIds(ats);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,8 +39,6 @@ export async function runCommand(
   args: string[],
 ): Promise<void> {
   try {
-    cmd.prerequisite?.();
-
     if (cmd.subCommands) {
       const [subCommand, ...subArgs] = args;
       const subCmd = cmd.subCommands[subCommand!];

--- a/packages/cli/src/portal/atsConsts.ts
+++ b/packages/cli/src/portal/atsConsts.ts
@@ -1,0 +1,2 @@
+export const atsTypes = ["greenhouse", "lever"] as const;
+export type ATS = (typeof atsTypes)[number];

--- a/packages/cli/src/portal/atsConsts.ts
+++ b/packages/cli/src/portal/atsConsts.ts
@@ -1,2 +1,2 @@
-export const atsTypes = ["greenhouse", "lever"] as const;
+export const atsTypes = ["ashby", "greenhouse", "lever"] as const;
 export type ATS = (typeof atsTypes)[number];

--- a/packages/cli/src/portal/pFuncs.ts
+++ b/packages/cli/src/portal/pFuncs.ts
@@ -1,12 +1,8 @@
 import { llm } from "../../../backend/src/ai/llm.ts";
 import { ats as atsObj } from "../../../backend/src/ats/ats.ts";
 import { CommandError, type Bag } from "../types.ts";
-import {
-  llmActionTypes,
-  type ATS,
-  type Context,
-  type LLMAction,
-} from "./pTypes.ts";
+import type { ATS } from "./atsConsts.ts";
+import { llmActionTypes, type Context, type LLMAction } from "./pTypes.ts";
 
 export { getLLMOptions } from "../../../backend/src/config.ts";
 

--- a/packages/cli/src/portal/pTypes.ts
+++ b/packages/cli/src/portal/pTypes.ts
@@ -19,9 +19,6 @@ export type {
   ExtractionSalaryRange as SalaryRange,
 };
 
-export const atsTypes = ["greenhouse", "lever"] as const;
-export type ATS = (typeof atsTypes)[number];
-
 export type LLMAction = keyof typeof llm;
 export const llmActionTypes = Object.getOwnPropertyNames(
   Object.getPrototypeOf(llm),

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -6,7 +6,6 @@ export type ENV = "prod" | "local";
 export interface Command {
   args: string;
   usage: string | string[];
-  prerequisite?(): void;
   subCommands?: Record<string, Command>;
   run?(args: string[]): Promise<void>;
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,6 +1,6 @@
 export type Bag = Record<string, unknown>;
 export type NumBag = Record<string, number>;
-export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
 export type ENV = "prod" | "local";
 
 export interface Command {

--- a/packages/cli/src/utils/utils.ts
+++ b/packages/cli/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { atsTypes, type ATS } from "../portal/pTypes.ts";
+import { atsTypes, type ATS } from "../portal/atsConsts.ts";
 import { CommandError } from "../types.ts";
 
 export function validateCompanyArgs([ats, ...companyIds]: string[]) {

--- a/packages/cli/test/e2e/step.test.ts
+++ b/packages/cli/test/e2e/step.test.ts
@@ -2,12 +2,10 @@ import assert from "node:assert/strict";
 import { after, suite, test } from "node:test";
 
 const originalAdminToken = process.env.ADMIN_TOKEN;
-const originalGreenhouseIds = process.env.GREENHOUSE_IDS;
-const originalLeverIds = process.env.LEVER_IDS;
+const originalE2eCompanies = process.env.E2E_COMPANIES;
 
 process.env.ADMIN_TOKEN = "test-admin-token-1";
-process.env.GREENHOUSE_IDS = "gh-1, gh-2";
-process.env.LEVER_IDS = "lv-1";
+process.env.E2E_COMPANIES = "ashby:ash-1|greenhouse:gh-1,gh-2|lever:lv-1";
 
 const {
   req,
@@ -29,16 +27,10 @@ suite("e2e step", () => {
       process.env.ADMIN_TOKEN = originalAdminToken;
     }
 
-    if (originalGreenhouseIds === undefined) {
-      delete process.env.GREENHOUSE_IDS;
+    if (originalE2eCompanies === undefined) {
+      delete process.env.E2E_COMPANIES;
     } else {
-      process.env.GREENHOUSE_IDS = originalGreenhouseIds;
-    }
-
-    if (originalLeverIds === undefined) {
-      delete process.env.LEVER_IDS;
-    } else {
-      process.env.LEVER_IDS = originalLeverIds;
+      process.env.E2E_COMPANIES = originalE2eCompanies;
     }
   });
 
@@ -169,7 +161,7 @@ suite("e2e step", () => {
         method: "PUT",
         path: "company",
         asAdmin: false,
-        body: { ats: "ashby", id: "stream" },
+        body: { ats: "ashby", id: "ash-1" },
       },
       res: { status: 200, value: undefined },
       confirm: undefined,
@@ -209,7 +201,7 @@ suite("e2e step", () => {
         method: "PUT",
         path: "companies",
         asAdmin: true,
-        body: { ats: "ashby", ids: ["stream"] },
+        body: { ats: "ashby", ids: ["ash-1"] },
       },
       res: { status: 200, value: undefined },
       confirm: "Verify ashby companies added",
@@ -241,16 +233,16 @@ suite("e2e step", () => {
   });
 
   test("allDelAts: delete step for every configured company id", () => {
-    // ashby: ["stream"], greenhouse: ["gh-1", "gh-2"], lever: ["lv-1"]
+    // ashby: ["ash-1"], greenhouse: ["gh-1", "gh-2"], lever: ["lv-1"]
     assert.equal(allDelAts.length, 4);
 
     assert.deepEqual(allDelAts[0], {
-      name: "Delete ashby company stream",
+      name: "Delete ashby company ash-1",
       req: {
         method: "DELETE",
         path: "company",
         asAdmin: true,
-        body: { ats: "ashby", id: "stream" },
+        body: { ats: "ashby", id: "ash-1" },
       },
       res: { status: 200, value: undefined },
       confirm: undefined,

--- a/packages/cli/test/e2e/step.test.ts
+++ b/packages/cli/test/e2e/step.test.ts
@@ -10,14 +10,15 @@ process.env.GREENHOUSE_IDS = "gh-1, gh-2";
 process.env.LEVER_IDS = "lv-1";
 
 const {
-  addCompaniesStep,
-  addCompanyStep,
-  delCompanyStep,
-  formAsyncStep,
-  formErrStep,
+  req,
+  res,
   formStep,
-  formSucStep,
-  resetSteps,
+  ats,
+  companyId,
+  companyIds,
+  oneAddEachAts,
+  allAddAts,
+  allDelAts,
 } = await import("../../src/e2e/step.ts");
 
 suite("e2e step", () => {
@@ -41,180 +42,257 @@ suite("e2e step", () => {
     }
   });
 
-  test("formStep: applies defaults and allows overrides", () => {
-    assert.deepEqual(formStep("jobs", "list jobs"), {
-      name: "list jobs",
-      path: "jobs",
+  test("req: builds request with method, path, asAdmin, and opts", () => {
+    assert.deepEqual(req("GET", "jobs", {}, false), {
       method: "GET",
-      asAdmin: false,
-      expectStatus: 200,
-    });
-
-    assert.deepEqual(
-      formStep("jobs", "create job", {
-        method: "POST",
-        asAdmin: true,
-        expectStatus: 201,
-      }),
-      {
-        name: "create job",
-        path: "jobs",
-        method: "POST",
-        asAdmin: true,
-        expectStatus: 201,
-      },
-    );
-  });
-
-  test("formSucStep: defaults to success body and supports overrides", () => {
-    assert.deepEqual(formSucStep("jobs", "sync jobs"), {
-      name: "sync jobs",
       path: "jobs",
-      method: "GET",
       asAdmin: false,
-      expectStatus: 200,
-      expectBody: { status: "success" },
     });
 
     assert.deepEqual(
-      formSucStep("jobs", "sync jobs", {
-        expectBody: { status: "custom" },
-      }),
+      req("POST", "company", { body: { ats: "lever", id: "lv-1" } }, true),
       {
-        name: "sync jobs",
-        path: "jobs",
-        method: "GET",
-        asAdmin: false,
-        expectStatus: 200,
-        expectBody: { status: "custom" },
-      },
-    );
-  });
-
-  test("formAsyncStep: applies async defaults and keeps explicit overrides", () => {
-    assert.deepEqual(formAsyncStep("jobs/sync", "sync now"), {
-      name: "sync now",
-      path: "jobs/sync",
-      method: "POST",
-      asAdmin: true,
-      expectStatus: 202,
-      expectBody: "Accepted",
-      asyncWait: "Verify Async Action",
-    });
-
-    assert.deepEqual(
-      formAsyncStep("jobs/sync", "sync now", {
-        expectStatus: 204,
-        asyncWait: "Custom async check",
-      }),
-      {
-        name: "sync now",
-        path: "jobs/sync",
         method: "POST",
-        asAdmin: true,
-        expectStatus: 204,
-        expectBody: "Accepted",
-        asyncWait: "Custom async check",
-      },
-    );
-  });
-
-  test("formErrStep: defaults to 400 error payload and honors custom status", () => {
-    assert.deepEqual(formErrStep("jobs", "invalid job", "Bad request"), {
-      name: "invalid job",
-      path: "jobs",
-      method: "GET",
-      asAdmin: false,
-      expectStatus: 400,
-      expectBody: {
-        status: "error",
-        statusCode: 400,
-        message: "Bad request",
-      },
-    });
-
-    assert.deepEqual(
-      formErrStep("jobs", "missing", "Not Found", {
-        expectStatus: 404,
-      }),
-      {
-        name: "missing",
-        path: "jobs",
-        method: "GET",
-        asAdmin: false,
-        expectStatus: 404,
-        expectBody: {
-          status: "error",
-          statusCode: 404,
-          message: "Not Found",
-        },
-      },
-    );
-  });
-
-  test("company step helpers: build admin company requests", () => {
-    assert.deepEqual(addCompanyStep("greenhouse", "gh-1"), {
-      name: "greenhouse / gh-1",
-      path: "company",
-      method: "PUT",
-      asAdmin: true,
-      expectStatus: 200,
-      expectBody: { status: "success" },
-      body: { ats: "greenhouse", id: "gh-1" },
-    });
-
-    assert.deepEqual(delCompanyStep("lever", "lv-2"), {
-      name: "lever / lv-2",
-      path: "company",
-      method: "DELETE",
-      asAdmin: true,
-      expectStatus: 200,
-      expectBody: { status: "success" },
-      body: { ats: "lever", id: "lv-2" },
-    });
-
-    assert.deepEqual(addCompaniesStep("greenhouse", ["gh-1", "gh-2"]), {
-      name: "greenhouse / [gh-1, gh-2]",
-      path: "companies",
-      method: "PUT",
-      asAdmin: true,
-      expectStatus: 200,
-      expectBody: { status: "success" },
-      body: { ats: "greenhouse", ids: ["gh-1", "gh-2"] },
-      asyncWait: undefined,
-    });
-  });
-
-  test("resetSteps: deletes configured ids and sets async wait on final step", () => {
-    assert.deepEqual(resetSteps, [
-      {
-        name: "greenhouse / gh-1",
         path: "company",
-        method: "DELETE",
         asAdmin: true,
-        expectStatus: 200,
-        expectBody: { status: "success" },
+        body: { ats: "lever", id: "lv-1" },
+      },
+    );
+  });
+
+  test("req shorthands: get is not admin, post/put/del default to admin", () => {
+    assert.deepEqual(req.get("jobs"), {
+      method: "GET",
+      path: "jobs",
+      asAdmin: false,
+    });
+
+    assert.deepEqual(req.post("jobs"), {
+      method: "POST",
+      path: "jobs",
+      asAdmin: true,
+    });
+
+    assert.deepEqual(req.put("company", { body: { ats: "ashby", id: "x" } }), {
+      method: "PUT",
+      path: "company",
+      asAdmin: true,
+      body: { ats: "ashby", id: "x" },
+    });
+
+    assert.deepEqual(
+      req.del("company", { body: { ats: "lever", id: "lv-1" } }),
+      {
+        method: "DELETE",
+        path: "company",
+        asAdmin: true,
+        body: { ats: "lever", id: "lv-1" },
+      },
+    );
+  });
+
+  test("req shorthands: opts can override the default asAdmin", () => {
+    assert.deepEqual(
+      req.put("company", {
+        asAdmin: false,
+        body: { ats: "greenhouse", id: "gh-1" },
+      }),
+      {
+        method: "PUT",
+        path: "company",
+        asAdmin: false,
         body: { ats: "greenhouse", id: "gh-1" },
       },
+    );
+  });
+
+  test("res: builds response with status and optional value", () => {
+    assert.deepEqual(res(200), { status: 200, value: undefined });
+    assert.deepEqual(res(201, "created"), { status: 201, value: "created" });
+  });
+
+  test("res.ok: returns 200 with optional value", () => {
+    assert.deepEqual(res.ok(), { status: 200, value: undefined });
+    assert.deepEqual(res.ok({ count: 3 }), {
+      status: 200,
+      value: { count: 3 },
+    });
+  });
+
+  test("res.err: defaults to 400 and builds error payload", () => {
+    assert.deepEqual(res.err("Bad request"), {
+      status: 400,
+      value: { status: "error", statusCode: 400, message: "Bad request" },
+    });
+
+    assert.deepEqual(res.err("Not Found", 404), {
+      status: 404,
+      value: { status: "error", statusCode: 404, message: "Not Found" },
+    });
+  });
+
+  test("res.accepted: is a 202 Accepted response", () => {
+    assert.deepEqual(res.accepted, { status: 202, value: "Accepted" });
+  });
+
+  test("formStep: builds a step with name, req, res, and optional confirm", () => {
+    assert.deepEqual(formStep("list jobs", req.get("jobs"), res.ok()), {
+      name: "list jobs",
+      req: { method: "GET", path: "jobs", asAdmin: false },
+      res: { status: 200, value: undefined },
+      confirm: undefined,
+    });
+
+    assert.deepEqual(
+      formStep("sync jobs", req.post("jobs/sync"), res.accepted, "Verify sync"),
       {
-        name: "greenhouse / gh-2",
+        name: "sync jobs",
+        req: { method: "POST", path: "jobs/sync", asAdmin: true },
+        res: { status: 202, value: "Accepted" },
+        confirm: "Verify sync",
+      },
+    );
+  });
+
+  test("constants: ats, companyId, companyIds reflect configured greenhouse ids", () => {
+    assert.equal(ats, "greenhouse");
+    assert.equal(companyId, "gh-1");
+    assert.deepEqual(companyIds, ["gh-1", "gh-2"]);
+  });
+
+  test("oneAddEachAts: one add step per ATS type using first id", () => {
+    assert.equal(oneAddEachAts.length, 3);
+
+    assert.deepEqual(oneAddEachAts[0], {
+      name: "Add ashby company",
+      req: {
+        method: "PUT",
         path: "company",
-        method: "DELETE",
+        asAdmin: false,
+        body: { ats: "ashby", id: "stream" },
+      },
+      res: { status: 200, value: undefined },
+      confirm: undefined,
+    });
+
+    assert.deepEqual(oneAddEachAts[1], {
+      name: "Add greenhouse company",
+      req: {
+        method: "PUT",
+        path: "company",
+        asAdmin: false,
+        body: { ats: "greenhouse", id: "gh-1" },
+      },
+      res: { status: 200, value: undefined },
+      confirm: undefined,
+    });
+
+    assert.deepEqual(oneAddEachAts[2], {
+      name: "Add lever company",
+      req: {
+        method: "PUT",
+        path: "company",
+        asAdmin: false,
+        body: { ats: "lever", id: "lv-1" },
+      },
+      res: { status: 200, value: undefined },
+      confirm: undefined,
+    });
+  });
+
+  test("allAddAts: add-all steps per ATS type with confirm messages", () => {
+    assert.equal(allAddAts.length, 3);
+
+    assert.deepEqual(allAddAts[0], {
+      name: "Add all ashby companies",
+      req: {
+        method: "PUT",
+        path: "companies",
         asAdmin: true,
-        expectStatus: 200,
-        expectBody: { status: "success" },
+        body: { ats: "ashby", ids: ["stream"] },
+      },
+      res: { status: 200, value: undefined },
+      confirm: "Verify ashby companies added",
+    });
+
+    assert.deepEqual(allAddAts[1], {
+      name: "Add all greenhouse companies",
+      req: {
+        method: "PUT",
+        path: "companies",
+        asAdmin: true,
+        body: { ats: "greenhouse", ids: ["gh-1", "gh-2"] },
+      },
+      res: { status: 200, value: undefined },
+      confirm: "Verify greenhouse companies added",
+    });
+
+    assert.deepEqual(allAddAts[2], {
+      name: "Add all lever companies",
+      req: {
+        method: "PUT",
+        path: "companies",
+        asAdmin: true,
+        body: { ats: "lever", ids: ["lv-1"] },
+      },
+      res: { status: 200, value: undefined },
+      confirm: "Verify lever companies added",
+    });
+  });
+
+  test("allDelAts: delete step for every configured company id", () => {
+    // ashby: ["stream"], greenhouse: ["gh-1", "gh-2"], lever: ["lv-1"]
+    assert.equal(allDelAts.length, 4);
+
+    assert.deepEqual(allDelAts[0], {
+      name: "Delete ashby company stream",
+      req: {
+        method: "DELETE",
+        path: "company",
+        asAdmin: true,
+        body: { ats: "ashby", id: "stream" },
+      },
+      res: { status: 200, value: undefined },
+      confirm: undefined,
+    });
+
+    assert.deepEqual(allDelAts[1], {
+      name: "Delete greenhouse company gh-1",
+      req: {
+        method: "DELETE",
+        path: "company",
+        asAdmin: true,
+        body: { ats: "greenhouse", id: "gh-1" },
+      },
+      res: { status: 200, value: undefined },
+      confirm: undefined,
+    });
+
+    assert.deepEqual(allDelAts[2], {
+      name: "Delete greenhouse company gh-2",
+      req: {
+        method: "DELETE",
+        path: "company",
+        asAdmin: true,
         body: { ats: "greenhouse", id: "gh-2" },
       },
-      {
-        name: "lever / lv-1",
-        path: "company",
+      res: { status: 200, value: undefined },
+      confirm: undefined,
+    });
+  });
+
+  test("allDelAts: last step has confirm set", () => {
+    const last = allDelAts.at(-1);
+    assert.deepEqual(last, {
+      name: "Delete lever company lv-1",
+      req: {
         method: "DELETE",
+        path: "company",
         asAdmin: true,
-        expectStatus: 200,
-        expectBody: { status: "success" },
         body: { ats: "lever", id: "lv-1" },
-        asyncWait: "Verify companies deleted and metadata reset",
       },
-    ]);
+      res: { status: 200, value: undefined },
+      confirm: "Verify companies deleted",
+    });
   });
 });


### PR DESCRIPTION
This pull request refactors the CLI's end-to-end (E2E) test configuration and flow system to make it more flexible and maintainable. The most significant change is replacing the old environment variable setup for test company IDs (separate variables for each ATS) with a unified, extensible format. The E2E test step and flow definitions have been rewritten for clarity and composability, and the configuration is now type-safe and validates ATS types. This makes it easier to add new ATS integrations and manage test companies.

**E2E Test Configuration Refactor:**

- Replaced `GREENHOUSE_IDS` and `LEVER_IDS` environment variables with a single `E2E_COMPANIES` variable, using a pipe-separated `ats:id1,id2` format for easier extension and parsing. Updated `.env.example` and documentation accordingly. [[1]](diffhunk://#diff-9c86492606708f79afa175c2307b950f6a43ea61e26c47f8c8a5cad82082a0a9L31-R35) [[2]](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51L68-R68)
- Added a parser and type-safe handling for `E2E_COMPANIES` in `config.ts`, with validation against known ATS types. [[1]](diffhunk://#diff-b080906034b38d1f3d445a6e93665228f1631f371704fd1c2f0b9ef84f9aefebR1-R2) [[2]](diffhunk://#diff-b080906034b38d1f3d445a6e93665228f1631f371704fd1c2f0b9ef84f9aefebL10-R12) [[3]](diffhunk://#diff-b080906034b38d1f3d445a6e93665228f1631f371704fd1c2f0b9ef84f9aefebR39-R58) [[4]](diffhunk://#diff-b080906034b38d1f3d445a6e93665228f1631f371704fd1c2f0b9ef84f9aefebL48-R69) [[5]](diffhunk://#diff-262daf06431065ea796854df794dae97978972d0491f4c835be8091c91bd1921R1-R2)

**E2E Test Step and Flow Redesign:**

- Rewrote the E2E step system: replaced previous ad-hoc helpers with a composable `formStep` API, and introduced structured request/response objects (`req`, `res`). Steps now explicitly define request/response and optional confirmation prompts.
- Simplified flow definitions in `flows.ts` using the new step system, making flows more readable and maintainable. Steps now use company IDs from the new config and are grouped by ATS dynamically.
- Removed hardcoded assertions and prerequisite checks for company IDs in favor of runtime validation and error messages. [[1]](diffhunk://#diff-e570604b59378dce42dc3e9b3062e7d5cf5d4cc7b5740f09a5234c0e07569bfeL3-L9) [[2]](diffhunk://#diff-e570604b59378dce42dc3e9b3062e7d5cf5d4cc7b5740f09a5234c0e07569bfeL18) [[3]](diffhunk://#diff-e570604b59378dce42dc3e9b3062e7d5cf5d4cc7b5740f09a5234c0e07569bfeL28-L32) [[4]](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL42-L43)

**Type and Import Cleanups:**

- Moved `ATS` type and `atsTypes` definition to a dedicated `atsConsts.ts` file, and updated all imports accordingly for clarity and reusability. [[1]](diffhunk://#diff-262daf06431065ea796854df794dae97978972d0491f4c835be8091c91bd1921R1-R2) [[2]](diffhunk://#diff-4f2045a9368ae269ced24afde9c38053cdad19b50f6b390f18e3dc3550b04df9L5-R6) [[3]](diffhunk://#diff-e71cbbd28c2687d44dad59eb3783f66c0cabc448fc11f060b375a54afbd0e87eL22-L24)

**Test Output and Error Handling Improvements:**

- Improved assertion error logging in E2E test runner to display expected/actual values for easier debugging.
- Updated step runner to use new request/response structure and confirmation messages. [[1]](diffhunk://#diff-e570604b59378dce42dc3e9b3062e7d5cf5d4cc7b5740f09a5234c0e07569bfeL64-R62) [[2]](diffhunk://#diff-e570604b59378dce42dc3e9b3062e7d5cf5d4cc7b5740f09a5234c0e07569bfeL76-R83)

These changes collectively make the E2E test setup more robust, easier to extend to new ATS types, and more maintainable for the future.