### PR TITLE
Deploy: etags prep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,59 +137,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-client": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
-      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.10.0",
-        "@azure/core-rest-pipeline": "^1.22.0",
-        "@azure/core-tracing": "^1.3.0",
-        "@azure/core-util": "^1.13.0",
-        "@azure/logger": "^1.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-client/node_modules/@azure/core-auth": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
-      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-util": "^1.13.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-client/node_modules/@azure/core-rest-pipeline": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
-      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.10.0",
-        "@azure/core-tracing": "^1.3.0",
-        "@azure/core-util": "^1.13.0",
-        "@azure/logger": "^1.3.0",
-        "@typespec/ts-http-runtime": "^0.3.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@azure/core-lro": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
@@ -336,26 +283,25 @@
       }
     },
     "node_modules/@azure/keyvault-keys": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.0.tgz",
-      "integrity": "sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.2.tgz",
+      "integrity": "sha512-VmUSLbXRAbSzDD8grXHGPaknYs0SKr3yuf6U+d4XMpX4XuVYskNqbTTwXce0zR1LyxfTZm9rWEBcvs3vdYwCmQ==",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/core-client": "^2.3.3",
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
         "@azure/core-lro": "^2.7.2",
         "@azure/core-paging": "^1.6.2",
         "@azure/core-rest-pipeline": "^1.19.0",
         "@azure/core-tracing": "^1.2.0",
         "@azure/core-util": "^1.11.0",
-        "@azure/keyvault-common": "^2.0.0",
+        "@azure/keyvault-common": "^2.1.0",
         "@azure/logger": "^1.1.4",
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/keyvault-keys/node_modules/@azure/core-auth": {
@@ -370,22 +316,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/keyvault-keys/node_modules/@azure/core-http-compat": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
-      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@azure/core-client": "^1.10.0",
-        "@azure/core-rest-pipeline": "^1.22.0"
       }
     },
     "node_modules/@azure/keyvault-keys/node_modules/@azure/core-rest-pipeline": {
@@ -438,9 +368,9 @@
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -519,9 +449,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
       "dev": true,
       "funding": [
         {
@@ -1358,14 +1288,14 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -1490,13 +1420,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.7.1.tgz",
-      "integrity": "sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.8.0.tgz",
+      "integrity": "sha512-P3ZM8BGJ5mwjtyfAxRyxsCyWHvaj+xahdhLoS3YiPsEyTHcWTVzx2691C8SrGkpvro3tNFCsWuNNrvM+spKODg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1506,9 +1436,9 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1521,12 +1451,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/resources": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1537,13 +1467,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2042,9 +1972,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2093,17 +2023,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
-      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/type-utils": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2116,7 +2046,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.0",
+        "@typescript-eslint/parser": "^8.61.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2132,16 +2062,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2182,14 +2112,14 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2229,14 +2159,14 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0"
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2247,9 +2177,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2264,15 +2194,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
-      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2314,9 +2244,9 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2328,16 +2258,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.0",
-        "@typescript-eslint/tsconfig-utils": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2381,9 +2311,9 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2394,16 +2324,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0"
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2418,13 +2348,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/types": "8.61.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2450,16 +2380,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2468,13 +2398,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2505,9 +2435,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2518,13 +2448,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2532,14 +2462,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2548,9 +2478,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2558,13 +2488,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2595,9 +2525,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2754,21 +2684,34 @@
       "license": "CC0-1.0"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3181,9 +3124,9 @@
       }
     },
     "node_modules/diagnostic-channel/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3475,11 +3418,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4162,9 +4108,9 @@
       "license": "MIT"
     },
     "node_modules/http-proxy-middleware": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.1.0.tgz",
-      "integrity": "sha512-XUOAjKncPZjsrgDTTem+CUED6A+piUAKTOwBM8g1gAublBX/GdxTHP8mO+og1EW1evYP8wd0G2c111tExwo/jw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.1.1.tgz",
+      "integrity": "sha512-KX5ZofGXLFXqFAkQoOWZ+rTtaLTut7m0gyL+QzJrdejtIZ+F4bPPDoe7reISg2+v0CAz5OfVwEJEhty7X+e57g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -4818,9 +4764,9 @@
       }
     },
     "node_modules/lucide-static": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-1.17.0.tgz",
-      "integrity": "sha512-VORJmPqi4DZ5lf4/n2qqcIz1nTKGFReS83DJINcK5nXY7z+4P3G6CW/7SXpzlGllEI0vHKFH24eSM+aMFaK5zw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-1.20.0.tgz",
+      "integrity": "sha512-kf7wqSk5UoTeOOMAzeewGSOXKJcAP61Q5Cpgx3AzGWIfRrr67Xyh2HZ0eRjzJs3XgPkcEtRSFILPiFmesmBmlg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5101,9 +5047,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -5343,9 +5289,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5605,9 +5551,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
-      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -5999,22 +5945,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.2"
+        "tldts-core": "^7.4.3"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6185,16 +6131,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
-      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.0",
-        "@typescript-eslint/parser": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0"
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6209,9 +6155,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6362,19 +6308,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6402,12 +6348,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3269,9 +3269,9 @@
       }
     },
     "node_modules/dry-utils-cosmosdb": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/dry-utils-cosmosdb/-/dry-utils-cosmosdb-0.6.1.tgz",
-      "integrity": "sha512-SHMovHw4bhlp2fRYHQUyrqAUOxsJmTbo03Kfm3rTENPKEh1G59E0yTmXTh/VWtEEqSfiT62qQ+yHa2cepat1pw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/dry-utils-cosmosdb/-/dry-utils-cosmosdb-0.6.2.tgz",
+      "integrity": "sha512-kSOjzqpTRB+ycn8JsD2MDWz1woCx+xMCHpyBngKET37dkR+wd2AsBowtCMEzhPwFNagpgx6YNwq+e2ETrSbgVw==",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^4.2.0"
@@ -6642,7 +6642,7 @@
         "applicationinsights": "^2.9.5",
         "cors": "^2.8.5",
         "dry-utils-async": "^0.3.2",
-        "dry-utils-cosmosdb": "^0.6.1",
+        "dry-utils-cosmosdb": "^0.6.2",
         "dry-utils-logger": "^0.2.0",
         "dry-utils-openai": "^0.4.2",
         "dry-utils-text": "^0.2.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "applicationinsights": "^2.9.5",
     "cors": "^2.8.5",
     "dry-utils-async": "^0.3.2",
-    "dry-utils-cosmosdb": "^0.6.1",
+    "dry-utils-cosmosdb": "^0.6.2",
     "dry-utils-logger": "^0.2.0",
     "dry-utils-openai": "^0.4.2",
     "dry-utils-text": "^0.2.1",

--- a/packages/backend/src/ats/ashby.ts
+++ b/packages/backend/src/ats/ashby.ts
@@ -16,10 +16,10 @@ export class Ashby extends ATSBase {
   }
 
   async getCompany({ id }: CompanyKey): Promise<Context<Company>> {
-    const companyResult = await this.fetchCompany(id);
-    const company = this.formatCompany(id);
+    const companyResult = await this.#fetchCompany(id);
+    const company = this.#formatCompany(id);
     if (companyResult.jobs.length > 0 && companyResult.jobs[0]) {
-      const exampleJob = this.formatJob(id, companyResult.jobs[0]);
+      const exampleJob = this.#formatJob(id, companyResult.jobs[0]);
 
       const context = {
         description: "Example job from the company",
@@ -39,8 +39,8 @@ export class Ashby extends ATSBase {
   }
 
   async getJobs({ id }: CompanyKey): Promise<Context<Job>[]> {
-    const { jobs } = await this.fetchCompany(id, true);
-    return jobs.map((job) => this.formatJob(id, job));
+    const { jobs } = await this.#fetchCompany(id, true);
+    return jobs.map((job) => this.#formatJob(id, job));
   }
 
   async getJob(jobKey: JobKey): Promise<Context<Job>> {
@@ -49,16 +49,16 @@ export class Ashby extends ATSBase {
     // We log an error so we can track if this accidentally happens in production
     logError("Ashby.getJob: This should never be called when deployed");
 
-    const { jobs } = await this.fetchCompany(jobKey.companyId, true);
+    const { jobs } = await this.#fetchCompany(jobKey.companyId, true);
     const job = jobs.find((job) => job.id === jobKey.id);
     if (!job) {
       throw new AppError("Job not found", 404);
     }
 
-    return this.formatJob(jobKey.companyId, job);
+    return this.#formatJob(jobKey.companyId, job);
   }
 
-  private formatCompany(id: string): Company {
+  #formatCompany(id: string): Company {
     id = id.trim();
     return {
       // Keys
@@ -71,14 +71,14 @@ export class Ashby extends ATSBase {
     };
   }
 
-  private formatJob(companyId: string, jobResult: JobResult): Context<Job> {
+  #formatJob(companyId: string, jobResult: JobResult): Context<Job> {
     if (jobResult.isListed === false) {
       logError(
         `Ashby.formatJob: ${companyId}\\${jobResult.id} marked as unlisted.`,
       );
     }
 
-    const result = this.formatJobBasic(companyId, jobResult);
+    const result = this.#formatJobBasic(companyId, jobResult);
 
     const {
       address,
@@ -114,7 +114,7 @@ export class Ashby extends ATSBase {
     return result;
   }
 
-  private async fetchCompany(
+  async #fetchCompany(
     id: string,
     includeComp: boolean = false,
   ): Promise<CompanyResult> {
@@ -122,7 +122,7 @@ export class Ashby extends ATSBase {
     return this.httpCall<CompanyResult>("Company", id, route);
   }
 
-  private formatJobBasic(
+  #formatJobBasic(
     companyId: string,
     { id, title, publishedAt, applyUrl }: JobResult,
   ): Context<Job> {

--- a/packages/backend/src/ats/ats.ts
+++ b/packages/backend/src/ats/ats.ts
@@ -12,7 +12,7 @@ import { Greenhouse } from "./greenhouse.ts";
 import { Lever } from "./lever.ts";
 
 class ATSConnector {
-  private readonly atsEndpoints: Record<ATS, ATSBase> = {
+  readonly #atsEndpoints: Record<ATS, ATSBase> = {
     greenhouse: new Greenhouse(),
     lever: new Lever(),
     ashby: new Ashby(),
@@ -20,25 +20,25 @@ class ATSConnector {
 
   /**
    * Retrieves company information from the appropriate ATS
-   * @param full - Whether to fetch full company details
+   * @param full Whether to fetch full company details
    */
   async getCompany(key: CompanyKey, full?: boolean): Promise<Context<Company>> {
-    return this.atsEndpoints[key.ats].getCompany(key, full);
+    return this.#atsEndpoints[key.ats].getCompany(key, full);
   }
 
   /**
    * Fetches jobs for a company from the appropriate ATS
-   * @param full - Whether to fetch full job details
+   * @param full Whether to fetch full job details
    */
   async getJobs(key: CompanyKey, full?: boolean): Promise<Context<Job>[]> {
-    return this.atsEndpoints[key.ats].getJobs(key, full);
+    return this.#atsEndpoints[key.ats].getJobs(key, full);
   }
 
   /**
    * Retrieves detailed information for a specific job
    */
   async getJob(key: CompanyKey, jobKey: JobKey): Promise<Context<Job>> {
-    return this.atsEndpoints[key.ats].getJob(jobKey);
+    return this.#atsEndpoints[key.ats].getJob(jobKey);
   }
 }
 

--- a/packages/backend/src/ats/atsBase.ts
+++ b/packages/backend/src/ats/atsBase.ts
@@ -59,6 +59,7 @@ export abstract class ATSBase {
   ): Promise<T> {
     const start = Date.now();
     let logStatus: StatusResponse;
+    let bytes = -1;
 
     try {
       const response = await fetch(`${this.#baseUrl}/${id}/${url}`, {
@@ -67,6 +68,7 @@ export abstract class ATSBase {
 
       const { status, statusText, ok } = response;
       logStatus = { status, statusText };
+      bytes = await this.#getContentLength(response);
 
       if (!ok) {
         if (status === 404) {
@@ -91,7 +93,23 @@ export abstract class ATSBase {
         status: 500,
         statusText: "Request Exception",
       };
-      logAtsCall(`GET ${name}`, this.#ats, id, duration, logStatus);
+      logAtsCall(`GET ${name}`, this.#ats, id, duration, bytes, logStatus);
+    }
+  }
+
+  async #getContentLength(res: Response) {
+    try {
+      // The easy way if the server supports it
+      const cl = res.headers.get("content-length");
+      if (cl != null) return Number(cl);
+
+      // The more annoying way
+      const buf = await res.clone().arrayBuffer();
+      return buf.byteLength;
+    } catch (error) {
+      // Length is only for telemetry, so just log and move on.
+      logError(error);
+      return -1;
     }
   }
 
@@ -117,10 +135,11 @@ function logAtsCall(
   ats: ATS,
   id: string,
   ms: number,
+  bytes: number,
   { status, statusText }: StatusResponse,
 ) {
   try {
-    const log: Bag = { name, ats, id, ms };
+    const log: Bag = { name, ats, id, ms, bytes };
 
     if (status !== 200) {
       log["status"] = status;
@@ -130,7 +149,7 @@ function logAtsCall(
     subscribeAggregator({
       tag: `${ats} ${name}`,
       dense: log,
-      metrics: { ms },
+      metrics: { ms, bytes },
       blob: {},
     });
   } catch (error) {

--- a/packages/backend/src/ats/atsBase.ts
+++ b/packages/backend/src/ats/atsBase.ts
@@ -16,17 +16,17 @@ type StatusResponse = { status: number; statusText: string };
  * providing common functionality and required interface
  */
 export abstract class ATSBase {
-  protected ats: ATS;
-  protected baseUrl: string;
+  readonly #ats: ATS;
+  readonly #baseUrl: string;
 
   constructor(ats: ATS, baseUrl: string) {
-    this.ats = ats;
-    this.baseUrl = baseUrl;
+    this.#ats = ats;
+    this.#baseUrl = baseUrl;
   }
 
   /**
    * Retrieves company information from the ATS
-   * @param full - Whether to fetch full job details
+   * @param full Whether to fetch full job details
    */
   abstract getCompany(
     key: CompanyKey,
@@ -35,7 +35,7 @@ export abstract class ATSBase {
 
   /**
    * Fetches jobs for a company from the ATS
-   * @param full - Whether to fetch full job details
+   * @param full Whether to fetch full job details
    */
   abstract getJobs(key: CompanyKey, full?: boolean): Promise<Context<Job>[]>;
 
@@ -46,9 +46,9 @@ export abstract class ATSBase {
 
   /**
    * Makes an HTTP GET request to the ATS API
-   * @param name - Name of the operation for logging
-   * @param id - Company identifier
-   * @param url - API endpoint URL
+   * @param name Name of the operation for logging
+   * @param id Company identifier
+   * @param url API endpoint URL
    * @returns API response data
    * @throws AppError for 404 or other error responses
    */
@@ -61,7 +61,7 @@ export abstract class ATSBase {
     let logStatus: StatusResponse;
 
     try {
-      const response = await fetch(`${this.baseUrl}/${id}/${url}`, {
+      const response = await fetch(`${this.#baseUrl}/${id}/${url}`, {
         signal: AbortSignal.timeout(15_000),
       });
 
@@ -70,32 +70,32 @@ export abstract class ATSBase {
 
       if (!ok) {
         if (status === 404) {
-          throw new AppError(`${this.ats} / ${id}: Not Found`, 404);
+          throw new AppError(`${this.#ats} / ${id}: Not Found`, 404);
         }
 
-        throw new AppError(`${this.ats} / ${id}: Request Failed`, 500);
+        throw new AppError(`${this.#ats} / ${id}: Request Failed`, 500);
       }
 
       return (await response.json()) as T;
     } catch (error) {
-      logStatus = this.errorToStatus(error);
+      logStatus = this.#errorToStatus(error);
 
       if (error instanceof AppError) {
         throw error;
       }
 
-      throw new AppError(`${this.ats} / ${id}: Request Failed`, 500, error);
+      throw new AppError(`${this.#ats} / ${id}: Request Failed`, 500, error);
     } finally {
       const duration = Date.now() - start;
       logStatus ??= {
         status: 500,
         statusText: "Request Exception",
       };
-      logAtsCall(`GET ${name}`, this.ats, id, duration, logStatus);
+      logAtsCall(`GET ${name}`, this.#ats, id, duration, logStatus);
     }
   }
 
-  private errorToStatus(error: unknown): StatusResponse {
+  #errorToStatus(error: unknown): StatusResponse {
     if (error instanceof AppError) {
       return { status: error.statusCode, statusText: error.message };
     }

--- a/packages/backend/src/ats/greenhouse.ts
+++ b/packages/backend/src/ats/greenhouse.ts
@@ -62,14 +62,14 @@ export class Greenhouse extends ATSBase {
     { id }: CompanyKey,
     full?: boolean,
   ): Promise<Context<Company>> {
-    const companyResult = await this.fetchCompany(id);
-    const company = this.formatCompany(id, companyResult);
+    const companyResult = await this.#fetchCompany(id);
+    const company = this.#formatCompany(id, companyResult);
 
     if (!full) {
       return { item: company };
     }
 
-    const { jobs } = await this.fetchJobsBasic(id);
+    const { jobs } = await this.#fetchJobsBasic(id);
 
     if (jobs.length) {
       const exampleJob = await this.getJob({
@@ -96,20 +96,20 @@ export class Greenhouse extends ATSBase {
 
   async getJobs({ id }: CompanyKey, full = false): Promise<Context<Job>[]> {
     if (!full) {
-      const { jobs } = await this.fetchJobsBasic(id);
-      return jobs.map((job) => this.formatJobBasic(id, job));
+      const { jobs } = await this.#fetchJobsBasic(id);
+      return jobs.map((job) => this.#formatJobBasic(id, job));
     } else {
-      const { jobs } = await this.fetchJobs(id);
-      return jobs.map((job) => this.formatJob(id, job));
+      const { jobs } = await this.#fetchJobs(id);
+      return jobs.map((job) => this.#formatJob(id, job));
     }
   }
 
   async getJob({ id, companyId }: JobKey): Promise<Context<Job>> {
-    const response = await this.fetchJob(companyId, id);
-    return this.formatJob(companyId, response);
+    const response = await this.#fetchJob(companyId, id);
+    return this.#formatJob(companyId, response);
   }
 
-  private formatCompany(id: string, { name, content }: CompanyResult): Company {
+  #formatCompany(id: string, { name, content }: CompanyResult): Company {
     return {
       // Keys
       id,
@@ -123,7 +123,7 @@ export class Greenhouse extends ATSBase {
     };
   }
 
-  private formatJobBasic(
+  #formatJobBasic(
     companyId: string,
     { id, title, updated_at, absolute_url }: JobResultBasic,
   ): Context<Job> {
@@ -143,8 +143,8 @@ export class Greenhouse extends ATSBase {
     return { item: job };
   }
 
-  private formatJob(companyId: string, jobResult: JobResult): Context<Job> {
-    const result = this.formatJobBasic(companyId, jobResult);
+  #formatJob(companyId: string, jobResult: JobResult): Context<Job> {
+    const result = this.#formatJobBasic(companyId, jobResult);
 
     const { id, metadata, content, departments, offices, location } = jobResult;
 
@@ -165,19 +165,19 @@ export class Greenhouse extends ATSBase {
     return result;
   }
 
-  private async fetchCompany(id: string): Promise<CompanyResult> {
+  async #fetchCompany(id: string): Promise<CompanyResult> {
     return this.httpCall<CompanyResult>("Company", id, "");
   }
 
-  private async fetchJob(id: string, jobId: string): Promise<JobResult> {
+  async #fetchJob(id: string, jobId: string): Promise<JobResult> {
     return this.httpCall<JobResult>("Job", id, `jobs/${jobId}`);
   }
 
-  private async fetchJobs(id: string): Promise<JobsResult> {
+  async #fetchJobs(id: string): Promise<JobsResult> {
     return this.httpCall<JobsResult>("Jobs", id, "/jobs?content=true");
   }
 
-  private async fetchJobsBasic(id: string): Promise<JobsResultBasic> {
+  async #fetchJobsBasic(id: string): Promise<JobsResultBasic> {
     return this.httpCall<JobsResultBasic>("JobsBasic", id, "/jobs");
   }
 }

--- a/packages/backend/src/ats/lever.ts
+++ b/packages/backend/src/ats/lever.ts
@@ -55,12 +55,12 @@ export class Lever extends ATSBase {
   }
 
   async getCompany({ id }: CompanyKey): Promise<Context<Company>> {
-    const [exampleJob] = await this.fetchJobs(id, true);
-    const company = this.formatCompany(id);
+    const [exampleJob] = await this.#fetchJobs(id, true);
+    const company = this.#formatCompany(id);
 
     if (!exampleJob) return { item: company };
 
-    const cleanJob = this.formatJob(id, exampleJob);
+    const cleanJob = this.#formatJob(id, exampleJob);
 
     const context = {
       description: "Example job from the company",
@@ -77,8 +77,8 @@ export class Lever extends ATSBase {
   }
 
   async getJobs({ id }: CompanyKey): Promise<Context<Job>[]> {
-    const jobs = await this.fetchJobs(id);
-    return jobs.map((job) => this.formatJob(id, job));
+    const jobs = await this.#fetchJobs(id);
+    return jobs.map((job) => this.#formatJob(id, job));
   }
 
   async getJob({ id, companyId }: JobKey): Promise<Context<Job>> {
@@ -87,17 +87,17 @@ export class Lever extends ATSBase {
     // We log an error so we can track if this accidentally happens in production
     logError("Lever.getJob: This should never be called when deployed");
 
-    const jobs = await this.fetchJobs(companyId);
+    const jobs = await this.#fetchJobs(companyId);
     const job = jobs.find((job) => job.id === id);
 
     if (!job) {
       throw new AppError("Job not found", 404);
     }
 
-    return this.formatJob(companyId, job);
+    return this.#formatJob(companyId, job);
   }
 
-  private formatCompany(id: string): Company {
+  #formatCompany(id: string): Company {
     return {
       // Keys
       id,
@@ -109,7 +109,7 @@ export class Lever extends ATSBase {
     };
   }
 
-  private formatJob(
+  #formatJob(
     companyId: string,
     {
       id,
@@ -162,7 +162,7 @@ export class Lever extends ATSBase {
     };
   }
 
-  private async fetchJobs(id: string, single = false): Promise<JobResult[]> {
+  async #fetchJobs(id: string, single = false): Promise<JobResult[]> {
     const query = single ? "?mode=json&limit=1" : "?mode=json";
     return this.httpCall<JobResult[]>("Jobs", id, query);
   }

--- a/packages/backend/src/controllers/job.ts
+++ b/packages/backend/src/controllers/job.ts
@@ -1,4 +1,4 @@
-import { Query } from "dry-utils-cosmosdb";
+import { Query, type Where } from "dry-utils-cosmosdb";
 import { llm } from "../ai/llm.ts";
 import { db } from "../db/db.ts";
 import type { Filters } from "../models/clientModels.ts";
@@ -7,8 +7,6 @@ import type { Job, JobKey } from "../models/models.ts";
 import { AppError } from "../utils/AppError.ts";
 import { MS_PER_DAY } from "../utils/constants.ts";
 import { logProperty } from "../utils/telemetry.ts";
-
-type Where = ReturnType<typeof Query.condition>;
 
 // Cosmos DB sorts missing values below defined numbers. That means:
 // - DESC numeric sorts place missing values after all defined values.

--- a/packages/backend/src/db/CompanyContainer.ts
+++ b/packages/backend/src/db/CompanyContainer.ts
@@ -1,0 +1,62 @@
+import { Container, type DBOptions } from "dry-utils-cosmosdb";
+import type { Company, CompanyKey, CompanyQuickRef } from "../models/models.ts";
+
+const ContainerName = "company";
+
+/** Database operations for ATS companies. */
+export class CompanyContainer extends Container<Company> {
+  /** Returns the Cosmos DB initialization options for this container. */
+  static ContainerOptions(): DBOptions["containers"][number] {
+    return {
+      name: ContainerName,
+      partitionKey: "ats",
+      indexExclusions: ["/description/?", "/website/?"],
+    };
+  }
+
+  /** Wraps an initialized company container. */
+  constructor(container: Container<Company>) {
+    super(ContainerName, container.container);
+  }
+
+  /** Gets a company by its ATS key. */
+  async get({ id, ats }: CompanyKey) {
+    return this.getItem(id, ats);
+  }
+
+  /** Gets company IDs for an ATS. */
+  async getIds(ats: string) {
+    return this.getIdsByPartitionKey(ats);
+  }
+
+  /** Gets all companies for an ATS. */
+  async getAll(ats: string) {
+    return this.getItemsByPartitionKey(ats);
+  }
+
+  /** Gets all company keys. */
+  async getKeys() {
+    return this.query<CompanyKey>(`SELECT c.id, c.ats FROM c`);
+  }
+
+  /** Gets compact company references used by job metadata. */
+  async getQuickRefs(): Promise<CompanyQuickRef[]> {
+    const refObjs = await this.query<{
+      id: string;
+      name: string;
+      website?: string;
+    }>("SELECT c.id, c.name, c.website FROM c");
+
+    return refObjs.map(({ id, name, website }) => [id, name, website]);
+  }
+
+  /** Creates or updates a company. */
+  async upsert(company: Company) {
+    await this.upsertItem(company);
+  }
+
+  /** Removes a company. */
+  async remove({ id, ats }: CompanyKey) {
+    return this.deleteItem(id, ats);
+  }
+}

--- a/packages/backend/src/db/CompanyContainer.ts
+++ b/packages/backend/src/db/CompanyContainer.ts
@@ -1,4 +1,4 @@
-import { Container, type DBOptions } from "dry-utils-cosmosdb";
+import { Container, type ContainerOptions } from "dry-utils-cosmosdb";
 import type { Company, CompanyKey, CompanyQuickRef } from "../models/models.ts";
 
 const ContainerName = "company";
@@ -6,7 +6,7 @@ const ContainerName = "company";
 /** Database operations for ATS companies. */
 export class CompanyContainer extends Container<Company> {
   /** Returns the Cosmos DB initialization options for this container. */
-  static ContainerOptions(): DBOptions["containers"][number] {
+  static ContainerOptions(): ContainerOptions {
     return {
       name: ContainerName,
       partitionKey: "ats",

--- a/packages/backend/src/db/IgnoreJobContainer.ts
+++ b/packages/backend/src/db/IgnoreJobContainer.ts
@@ -1,5 +1,5 @@
 import { batch } from "dry-utils-async";
-import { Container, type DBOptions } from "dry-utils-cosmosdb";
+import { Container, type ContainerOptions } from "dry-utils-cosmosdb";
 import type { CompanyKey, IgnoreJob } from "../models/models.ts";
 import { JOB_EXPIRY_SEC } from "../utils/constants.ts";
 
@@ -8,7 +8,7 @@ const ContainerName = "ignoreJob";
 /** Database operations for jobs excluded from ATS synchronization. */
 export class IgnoreJobContainer extends Container<IgnoreJob> {
   /** Returns the Cosmos DB initialization options for this container. */
-  static ContainerOptions(): DBOptions["containers"][number] {
+  static ContainerOptions(): ContainerOptions {
     return {
       name: ContainerName,
       partitionKey: "atsCompany",

--- a/packages/backend/src/db/IgnoreJobContainer.ts
+++ b/packages/backend/src/db/IgnoreJobContainer.ts
@@ -1,0 +1,55 @@
+import { batch } from "dry-utils-async";
+import { Container, type DBOptions } from "dry-utils-cosmosdb";
+import type { CompanyKey, IgnoreJob } from "../models/models.ts";
+import { JOB_EXPIRY_SEC } from "../utils/constants.ts";
+
+const ContainerName = "ignoreJob";
+
+/** Database operations for jobs excluded from ATS synchronization. */
+export class IgnoreJobContainer extends Container<IgnoreJob> {
+  /** Returns the Cosmos DB initialization options for this container. */
+  static ContainerOptions(): DBOptions["containers"][number] {
+    return {
+      name: ContainerName,
+      partitionKey: "atsCompany",
+      ttlSeconds: JOB_EXPIRY_SEC,
+      indexExclusions: "all",
+    };
+  }
+
+  /** Wraps an initialized ignored-job container. */
+  constructor(container: Container<IgnoreJob>) {
+    super(ContainerName, container.container);
+  }
+
+  /** Gets an ignored job for a company. */
+  async get(jobId: string, key: CompanyKey) {
+    return this.getItem(jobId, this.#asPKey(key));
+  }
+
+  /** Gets all ignored job IDs for a company. */
+  async getIds(key: CompanyKey) {
+    return this.getIdsByPartitionKey(this.#asPKey(key));
+  }
+
+  /** Creates or updates an ignored job. */
+  async upsert(jobId: string, key: CompanyKey, reason: string) {
+    await this.upsertItem({
+      id: jobId,
+      atsCompany: this.#asPKey(key),
+      reason,
+    });
+  }
+
+  /** Creates or updates several ignored jobs for a company. */
+  async upsertMany(jobIds: string[], key: CompanyKey, reason: string) {
+    const atsCompany = this.#asPKey(key);
+    return await batch("UpsertIgnoreJob", jobIds, async (id) => {
+      await this.upsertItem({ id, atsCompany, reason });
+    });
+  }
+
+  #asPKey({ ats, id }: CompanyKey) {
+    return `${ats}+${id}`;
+  }
+}

--- a/packages/backend/src/db/JobContainer.ts
+++ b/packages/backend/src/db/JobContainer.ts
@@ -1,0 +1,105 @@
+import { batch } from "dry-utils-async";
+import { Container, type DBOptions } from "dry-utils-cosmosdb";
+import { JobFamily, Presence } from "../models/enums.ts";
+import type { Job, JobKey, Metadata } from "../models/models.ts";
+import { MS_PER_DAY } from "../utils/constants.ts";
+
+const ContainerName = "job";
+
+/** Database operations for jobs. */
+export class JobContainer extends Container<Job> {
+  /** Returns the Cosmos DB initialization options for this container. */
+  static ContainerOptions(): DBOptions["containers"][number] {
+    return {
+      name: ContainerName,
+      partitionKey: "companyId",
+    };
+  }
+
+  /** Wraps an initialized job container. */
+  constructor(container: Container<Job>) {
+    super(ContainerName, container.container);
+  }
+
+  /** Gets a job by its key. */
+  async get({ id, companyId }: JobKey) {
+    return this.getItem(id, companyId);
+  }
+
+  /** Gets all job IDs for a company. */
+  async getIds(companyId: string) {
+    return this.getIdsByPartitionKey(companyId);
+  }
+
+  /** Gets all jobs for a company. */
+  async getAll(companyId: string) {
+    return this.getItemsByPartitionKey(companyId);
+  }
+
+  /** Gets job IDs and Cosmos timestamps for a company. */
+  async getIdsAndTimestamps(companyId: string) {
+    return this.query<{ id: string; _ts: number }>(
+      "SELECT c.id, c._ts FROM c",
+      { partitionKey: companyId },
+    );
+  }
+
+  /** Gets IDs of companies that have jobs. */
+  async getCompanyIds(): Promise<string[]> {
+    return await this.query<string>("SELECT DISTINCT VALUE c.companyId FROM c");
+  }
+
+  /** Creates or updates a job. */
+  async upsert(job: Job) {
+    await this.upsertItem(job);
+  }
+
+  /** Removes a job. */
+  async remove({ id, companyId }: JobKey) {
+    return this.deleteItem(id, companyId);
+  }
+
+  /** Removes several jobs for a company. */
+  async removeMany(jobIds: string[], companyId: string) {
+    return await batch("DeleteJob", jobIds, (id) =>
+      this.remove({ id, companyId }),
+    );
+  }
+
+  /** Aggregates job metadata used by search filters and site statistics. */
+  async aggregateMetadata(): Promise<Metadata> {
+    const weekMs = Date.now() - 7 * MS_PER_DAY;
+
+    const [jobCount, recentJobCount, presenceRows, jobFamilyRows] =
+      await Promise.all([
+        this.getCount(),
+        this.getCount(["postTS", ">=", weekMs]),
+        this.getCountBy("presence"),
+        this.getCountBy("jobFamily"),
+      ]);
+
+    const presenceCounts: Partial<Record<Presence, number>> = {};
+    presenceRows.forEach(({ name, count }) => {
+      const parsed = Presence.safeParse(name);
+      if (parsed.success) {
+        presenceCounts[parsed.data] = count;
+      }
+    });
+
+    const jobFamilyCounts: Partial<Record<JobFamily, number>> = {};
+    jobFamilyRows.forEach(({ name, count }) => {
+      const parsed = JobFamily.safeParse(name);
+      if (parsed.success) {
+        jobFamilyCounts[parsed.data] = count;
+      }
+    });
+
+    return {
+      id: "job",
+      jobCount,
+      recentJobCount,
+      presenceCounts,
+      jobFamilyCounts,
+    };
+  }
+}

--- a/packages/backend/src/db/JobContainer.ts
+++ b/packages/backend/src/db/JobContainer.ts
@@ -1,5 +1,5 @@
 import { batch } from "dry-utils-async";
-import { Container, type DBOptions } from "dry-utils-cosmosdb";
+import { Container, type ContainerOptions } from "dry-utils-cosmosdb";
 import { JobFamily, Presence } from "../models/enums.ts";
 import type { Job, JobKey, Metadata } from "../models/models.ts";
 import { MS_PER_DAY } from "../utils/constants.ts";
@@ -9,7 +9,7 @@ const ContainerName = "job";
 /** Database operations for jobs. */
 export class JobContainer extends Container<Job> {
   /** Returns the Cosmos DB initialization options for this container. */
-  static ContainerOptions(): DBOptions["containers"][number] {
+  static ContainerOptions(): ContainerOptions {
     return {
       name: ContainerName,
       partitionKey: "companyId",

--- a/packages/backend/src/db/cache.ts
+++ b/packages/backend/src/db/cache.ts
@@ -2,6 +2,7 @@ import { AppError } from "../utils/AppError.ts";
 import { logCounter, logError } from "../utils/telemetry.ts";
 import { db } from "./db.ts";
 import { LRUCache } from "./lruCache.ts";
+import { normalizeId } from "./utils.ts";
 
 const locationMemoryCache = new LRUCache<string, string>(1000);
 
@@ -9,7 +10,8 @@ export async function getCachedLocation(
   locationText: string,
 ): Promise<string | undefined> {
   try {
-    const key = normalize(locationText);
+    const key = normalizeId(locationText);
+    if (!key) return undefined;
     const cachedResult = locationMemoryCache.get(key);
 
     if (cachedResult) {
@@ -36,7 +38,8 @@ export async function getCachedLocation(
 
 export function setCachedLocation(locationText: string, city: string) {
   try {
-    const key = normalize(locationText);
+    const key = normalizeId(locationText);
+    if (!key) return;
     locationMemoryCache.set(key, city);
 
     // Don't await on cache insertion
@@ -48,14 +51,4 @@ export function setCachedLocation(locationText: string, city: string) {
   } catch (e) {
     logError(new AppError("SetCachedLocation", undefined, e));
   }
-}
-
-function normalize(key: string) {
-  return (
-    key
-      .toLowerCase()
-      .trim()
-      // ['/', '\\', '#'] cannot be used in CosmosDB keys (ie. for the DB cache)
-      .replace(/[/\\#]/g, "_")
-  );
 }

--- a/packages/backend/src/db/db.ts
+++ b/packages/backend/src/db/db.ts
@@ -1,4 +1,3 @@
-import { batch } from "dry-utils-async";
 import {
   Container,
   connectDB,
@@ -6,181 +5,27 @@ import {
   subscribeCosmosDBLogging,
 } from "dry-utils-cosmosdb";
 import { config } from "../config.ts";
-import { JobFamily, Presence } from "../models/enums.ts";
 import type {
   Company,
-  CompanyKey,
-  CompanyQuickRef,
   IgnoreJob,
   Job,
-  JobKey,
   Location,
   Metadata,
 } from "../models/models.ts";
-import { JOB_EXPIRY_SEC, MS_PER_DAY } from "../utils/constants.ts";
 import {
   createSubscribeAggregator,
   subscribeError,
   subscribeLog,
 } from "../utils/telemetry.ts";
+import { CompanyContainer } from "./CompanyContainer.ts";
+import { IgnoreJobContainer } from "./IgnoreJobContainer.ts";
+import { JobContainer } from "./JobContainer.ts";
 
 subscribeCosmosDBLogging({
   log: subscribeLog,
   error: subscribeError,
   aggregate: createSubscribeAggregator("db", 10),
 });
-
-class CompanyContainer extends Container<Company> {
-  constructor(container: Container<Company>) {
-    super("company", container.container);
-  }
-
-  async get({ id, ats }: CompanyKey) {
-    return this.getItem(id, ats);
-  }
-
-  async getIds(ats: string) {
-    return this.getIdsByPartitionKey(ats);
-  }
-
-  async getAll(ats: string) {
-    return this.getItemsByPartitionKey(ats);
-  }
-
-  async getKeys() {
-    return this.query<CompanyKey>(`SELECT c.id, c.ats FROM c`);
-  }
-
-  async getQuickRefs(): Promise<CompanyQuickRef[]> {
-    const refObjs = await this.query<{
-      id: string;
-      name: string;
-      website?: string;
-    }>("SELECT c.id, c.name, c.website FROM c");
-
-    return refObjs.map(({ id, name, website }) => [id, name, website]);
-  }
-
-  async upsert(company: Company) {
-    await this.upsertItem(company);
-  }
-
-  async remove({ id, ats }: CompanyKey) {
-    return this.deleteItem(id, ats);
-  }
-}
-
-class JobContainer extends Container<Job> {
-  constructor(container: Container<Job>) {
-    super("job", container.container);
-  }
-
-  async get({ id, companyId }: JobKey) {
-    return this.getItem(id, companyId);
-  }
-
-  async getIds(companyId: string) {
-    return this.getIdsByPartitionKey(companyId);
-  }
-
-  async getAll(companyId: string) {
-    return this.getItemsByPartitionKey(companyId);
-  }
-
-  async getIdsAndTimestamps(companyId: string) {
-    return this.query<{ id: string; _ts: number }>(
-      "SELECT c.id, c._ts FROM c",
-      { partitionKey: companyId },
-    );
-  }
-
-  async getCompanyIds(): Promise<string[]> {
-    return await this.query<string>("SELECT DISTINCT VALUE c.companyId FROM c");
-  }
-
-  async upsert(job: Job) {
-    await this.upsertItem(job);
-  }
-
-  async remove({ id, companyId }: JobKey) {
-    return this.deleteItem(id, companyId);
-  }
-
-  async removeMany(jobIds: string[], companyId: string) {
-    return await batch("DeleteJob", jobIds, (id) =>
-      this.remove({ id, companyId }),
-    );
-  }
-
-  async aggregateMetadata(): Promise<Metadata> {
-    const weekMs = Date.now() - 7 * MS_PER_DAY;
-
-    const [jobCount, recentJobCount, presenceRows, jobFamilyRows] =
-      await Promise.all([
-        this.getCount(),
-        this.getCount(["postTS", ">=", weekMs]),
-        this.getCountBy("presence"),
-        this.getCountBy("jobFamily"),
-      ]);
-
-    const presenceCounts: Partial<Record<Presence, number>> = {};
-    presenceRows.forEach(({ name, count }) => {
-      const parsed = Presence.safeParse(name);
-      if (parsed.success) {
-        presenceCounts[parsed.data] = count;
-      }
-    });
-
-    const jobFamilyCounts: Partial<Record<JobFamily, number>> = {};
-    jobFamilyRows.forEach(({ name, count }) => {
-      const parsed = JobFamily.safeParse(name);
-      if (parsed.success) {
-        jobFamilyCounts[parsed.data] = count;
-      }
-    });
-
-    return {
-      id: "job",
-      jobCount,
-      recentJobCount,
-      presenceCounts,
-      jobFamilyCounts,
-    };
-  }
-}
-
-class IgnoreJobContainer extends Container<IgnoreJob> {
-  constructor(container: Container<IgnoreJob>) {
-    super("ignoreJob", container.container);
-  }
-
-  async get(jobId: string, key: CompanyKey) {
-    return this.getItem(jobId, this.#asPKey(key));
-  }
-
-  async getIds(key: CompanyKey) {
-    return this.getIdsByPartitionKey(this.#asPKey(key));
-  }
-
-  async upsert(jobId: string, key: CompanyKey, reason: string) {
-    await this.upsertItem({
-      id: jobId,
-      atsCompany: this.#asPKey(key),
-      reason,
-    });
-  }
-
-  async upsertMany(jobIds: string[], key: CompanyKey, reason: string) {
-    const atsCompany = this.#asPKey(key);
-    return await batch("UpsertIgnoreJob", jobIds, async (id) => {
-      await this.upsertItem({ id, atsCompany, reason });
-    });
-  }
-
-  #asPKey({ ats, id }: CompanyKey) {
-    return `${ats}+${id}`;
-  }
-}
 
 class DB {
   #company: CompanyContainer | undefined;
@@ -227,21 +72,9 @@ class DB {
         mockDataPath: config.DATABASE_MOCK_DATA_PATH,
       }),
       containers: [
-        {
-          name: "company",
-          partitionKey: "ats",
-          indexExclusions: ["/description/?", "/website/?"],
-        },
-        {
-          name: "job",
-          partitionKey: "companyId",
-        },
-        {
-          name: "ignoreJob",
-          partitionKey: "atsCompany",
-          ttlSeconds: JOB_EXPIRY_SEC,
-          indexExclusions: "all",
-        },
+        CompanyContainer.ContainerOptions(),
+        JobContainer.ContainerOptions(),
+        IgnoreJobContainer.ContainerOptions(),
         {
           name: "metadata",
           partitionKey: "id",

--- a/packages/backend/src/db/utils.ts
+++ b/packages/backend/src/db/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Useful if you have an arbitrary string that needs to become a cosmosDB id
+ */
+export function normalizeId(key: string) {
+  return (
+    key
+      .toLowerCase()
+      .trim()
+      // ['/', '\\', '#', '?'] cannot be used in CosmosDB keys
+      .replace(/[/\\#?]/g, "_")
+  );
+}

--- a/packages/backend/src/utils/telemetry.ts
+++ b/packages/backend/src/utils/telemetry.ts
@@ -103,6 +103,35 @@ export function withAsyncContext(
 }
 
 /**
+ * Executes an async function within a local telemetry context and logs the
+ * captured summary when the function settles.
+ * @param name Name of the operation for the log summary.
+ * @param fn Async function to execute.
+ * @returns The resolved value from the async function.
+ * @remarks Intended for in-process callers, such as CLI portal functions, that
+ * need backend telemetry context without starting Application Insights.
+ */
+export function withLocalTelemetryContext<T>(
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = Date.now();
+  const context: Bag = {};
+
+  return asyncLocalStorage.run(context, async () => {
+    try {
+      return await fn();
+    } finally {
+      logger.debug(new Date().toISOString(), {
+        name,
+        duration: Date.now() - start,
+        ...context,
+      });
+    }
+  });
+}
+
+/**
  * Get the current logging context, initializing it if necessary
  */
 function getContext(): Bag {

--- a/packages/backend/test/db/CompanyContainer.test.ts
+++ b/packages/backend/test/db/CompanyContainer.test.ts
@@ -1,0 +1,66 @@
+import { connectDB, Container } from "dry-utils-cosmosdb";
+import assert from "node:assert/strict";
+import { before, suite, test } from "node:test";
+import { CompanyContainer } from "../../src/db/CompanyContainer.ts";
+import type { Company } from "../../src/models/models.ts";
+
+suite("CompanyContainer", () => {
+  let company: CompanyContainer;
+
+  before(async () => {
+    const containers = await connectDB({
+      endpoint: "unused-for-mock",
+      key: "unused-for-mock",
+      name: "unused-for-mock",
+      containers: [CompanyContainer.ContainerOptions()],
+      mockDBData: {
+        company: [
+          { id: "acme", ats: "greenhouse", name: "Acme", website: "acme.com" },
+          { id: "beta", ats: "greenhouse", name: "Beta" },
+          { id: "acme", ats: "lever", name: "Lever Acme" },
+        ],
+      },
+    });
+
+    company = new CompanyContainer(
+      containers["company"]! as Container<Company>,
+    );
+  });
+
+  test("defines its container options", () => {
+    assert.deepEqual(CompanyContainer.ContainerOptions(), {
+      name: "company",
+      partitionKey: "ats",
+      indexExclusions: ["/description/?", "/website/?"],
+    });
+  });
+
+  test("reads companies and projections", async () => {
+    assert.equal(
+      (await company.get({ id: "acme", ats: "greenhouse" }))?.name,
+      "Acme",
+    );
+    assert.deepEqual(await company.getIds("greenhouse"), ["acme", "beta"]);
+    assert.equal((await company.getAll("greenhouse")).length, 2);
+    assert.deepEqual(await company.getKeys(), [
+      { id: "acme", ats: "greenhouse" },
+      { id: "beta", ats: "greenhouse" },
+      { id: "acme", ats: "lever" },
+    ]);
+    assert.deepEqual(await company.getQuickRefs(), [
+      ["acme", "Acme", "acme.com"],
+      ["beta", "Beta", undefined],
+      ["acme", "Lever Acme", undefined],
+    ]);
+  });
+
+  test("saves and removes companies", async () => {
+    const saved = { id: "new", ats: "lever", name: "New Company" } as const;
+
+    await company.upsert(saved);
+    assert.deepEqual(await company.get(saved), saved);
+
+    await company.remove(saved);
+    assert.equal(await company.get(saved), undefined);
+  });
+});

--- a/packages/backend/test/db/CompanyContainer.test.ts
+++ b/packages/backend/test/db/CompanyContainer.test.ts
@@ -16,7 +16,7 @@ suite("CompanyContainer", () => {
       mockDBData: {
         company: [
           { id: "acme", ats: "greenhouse", name: "Acme", website: "acme.com" },
-          { id: "beta", ats: "greenhouse", name: "Beta" },
+          { id: "beta%20inc", ats: "greenhouse", name: "Beta" },
           { id: "acme", ats: "lever", name: "Lever Acme" },
         ],
       },
@@ -40,16 +40,19 @@ suite("CompanyContainer", () => {
       (await company.get({ id: "acme", ats: "greenhouse" }))?.name,
       "Acme",
     );
-    assert.deepEqual(await company.getIds("greenhouse"), ["acme", "beta"]);
+    assert.deepEqual(await company.getIds("greenhouse"), [
+      "acme",
+      "beta%20inc",
+    ]);
     assert.equal((await company.getAll("greenhouse")).length, 2);
     assert.deepEqual(await company.getKeys(), [
       { id: "acme", ats: "greenhouse" },
-      { id: "beta", ats: "greenhouse" },
+      { id: "beta%20inc", ats: "greenhouse" },
       { id: "acme", ats: "lever" },
     ]);
     assert.deepEqual(await company.getQuickRefs(), [
       ["acme", "Acme", "acme.com"],
-      ["beta", "Beta", undefined],
+      ["beta%20inc", "Beta", undefined],
       ["acme", "Lever Acme", undefined],
     ]);
   });

--- a/packages/backend/test/db/IgnoreJobContainer.test.ts
+++ b/packages/backend/test/db/IgnoreJobContainer.test.ts
@@ -1,0 +1,47 @@
+import { connectDB, Container } from "dry-utils-cosmosdb";
+import assert from "node:assert/strict";
+import { before, suite, test } from "node:test";
+import { IgnoreJobContainer } from "../../src/db/IgnoreJobContainer.ts";
+import type { IgnoreJob } from "../../src/models/models.ts";
+import { JOB_EXPIRY_SEC } from "../../src/utils/constants.ts";
+
+suite("IgnoreJobContainer", () => {
+  let ignoreJob: IgnoreJobContainer;
+
+  before(async () => {
+    const containers = await connectDB({
+      endpoint: "unused-for-mock",
+      key: "unused-for-mock",
+      name: "unused-for-mock",
+      containers: [IgnoreJobContainer.ContainerOptions()],
+      mockDBData: { ignoreJob: [] },
+    });
+
+    ignoreJob = new IgnoreJobContainer(
+      containers["ignoreJob"]! as Container<IgnoreJob>,
+    );
+  });
+
+  test("defines its container options", () => {
+    assert.deepEqual(IgnoreJobContainer.ContainerOptions(), {
+      name: "ignoreJob",
+      partitionKey: "atsCompany",
+      ttlSeconds: JOB_EXPIRY_SEC,
+      indexExclusions: "all",
+    });
+  });
+
+  test("saves and reads ignored jobs using the company key", async () => {
+    const key = { id: "acme", ats: "greenhouse" } as const;
+
+    await ignoreJob.upsert("one", key, "Manual");
+    assert.equal((await ignoreJob.get("one", key))?.reason, "Manual");
+
+    await ignoreJob.upsertMany(["two", "three"], key, "Expired");
+    assert.deepEqual(await ignoreJob.getIds(key), ["one", "two", "three"]);
+    assert.equal(
+      (await ignoreJob.get("two", key))?.atsCompany,
+      "greenhouse+acme",
+    );
+  });
+});

--- a/packages/backend/test/db/JobContainer.test.ts
+++ b/packages/backend/test/db/JobContainer.test.ts
@@ -1,0 +1,107 @@
+import { connectDB, Container } from "dry-utils-cosmosdb";
+import assert from "node:assert/strict";
+import { beforeEach, suite, test } from "node:test";
+import { JobContainer } from "../../src/db/JobContainer.ts";
+import type { Job } from "../../src/models/models.ts";
+import { MS_PER_DAY } from "../../src/utils/constants.ts";
+
+const now = Date.now();
+const job = (
+  id: string,
+  companyId: string,
+  postTS: number,
+  extras: Partial<Job> = {},
+): Job => ({
+  id,
+  companyId,
+  title: `Job ${id}`,
+  description: "",
+  postTS,
+  applyUrl: `https://example.com/${id}`,
+  ...extras,
+});
+
+suite("JobContainer", () => {
+  let jobs: JobContainer;
+
+  beforeEach(async () => {
+    const containers = await connectDB({
+      endpoint: "unused-for-mock",
+      key: "unused-for-mock",
+      name: "unused-for-mock",
+      containers: [JobContainer.ContainerOptions()],
+      mockDBData: {
+        job: [
+          { ...job("one", "acme", now), _ts: 100 },
+          {
+            ...job("two", "acme", now - 8 * MS_PER_DAY, {
+              presence: "remote",
+              jobFamily: "engineering",
+            }),
+            _ts: 200,
+          },
+          {
+            ...job("three", "beta", now, {
+              presence: "remote",
+              jobFamily: "design",
+            }),
+            _ts: 300,
+          },
+        ],
+      },
+      mockDBProjects: {
+        job: [
+          {
+            matcher: "DISTINCT VALUE c.companyId",
+            fn: ({ items }) => [
+              ...new Set(items.map((item) => item["companyId"])),
+            ],
+          },
+        ],
+      },
+    });
+
+    jobs = new JobContainer(containers["job"]! as Container<Job>);
+  });
+
+  test("defines its container options", () => {
+    assert.deepEqual(JobContainer.ContainerOptions(), {
+      name: "job",
+      partitionKey: "companyId",
+    });
+  });
+
+  test("reads jobs and projections", async () => {
+    assert.equal((await jobs.get({ id: "one", companyId: "acme" }))?.id, "one");
+    assert.deepEqual(await jobs.getIds("acme"), ["one", "two"]);
+    assert.equal((await jobs.getAll("acme")).length, 2);
+    assert.deepEqual(await jobs.getIdsAndTimestamps("acme"), [
+      { id: "one", _ts: 100 },
+      { id: "two", _ts: 200 },
+    ]);
+    assert.deepEqual(await jobs.getCompanyIds(), ["acme", "beta"]);
+  });
+
+  test("saves and removes jobs", async () => {
+    const saved = job("new", "new-company", now);
+
+    await jobs.upsert(saved);
+    assert.equal((await jobs.get(saved))?.title, saved.title);
+
+    await jobs.remove(saved);
+    assert.equal(await jobs.get(saved), undefined);
+
+    await jobs.removeMany(["one", "two"], "acme");
+    assert.deepEqual(await jobs.getIds("acme"), []);
+  });
+
+  test("aggregates job metadata", async () => {
+    assert.deepEqual(await jobs.aggregateMetadata(), {
+      id: "job",
+      jobCount: 3,
+      recentJobCount: 2,
+      presenceCounts: { remote: 2 },
+      jobFamilyCounts: { engineering: 1, design: 1 },
+    });
+  });
+});

--- a/packages/backend/test/setup.ts
+++ b/packages/backend/test/setup.ts
@@ -1,5 +1,10 @@
+import { configureGlobal } from "dry-utils-logger";
 import express from "express";
 import { mock } from "node:test";
+
+configureGlobal({
+  filename: "logs/test.log",
+});
 
 process.env.ADMIN_TOKEN ??= "test-admin-token-123456";
 process.env.NODE_ENV ??= "test";

--- a/packages/backend/test/utils/telemetry.test.ts
+++ b/packages/backend/test/utils/telemetry.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { suite, test } from "node:test";
+import timers from "node:timers/promises";
+import {
+  createSubscribeAggregator,
+  logCounter,
+  logProperty,
+  withLocalTelemetryContext,
+} from "../../src/utils/telemetry.ts";
+
+async function waitForLogText(expected: string): Promise<string> {
+  const start = Date.now();
+  let text = "";
+
+  while (Date.now() - start < 500) {
+    text = await readFile("logs/test.log", "utf8").catch(() => "");
+
+    if (text.includes(expected)) {
+      return text;
+    }
+
+    await timers.setTimeout(10);
+  }
+
+  return text;
+}
+
+suite("telemetry", () => {
+  test("withLocalTelemetryContext: returns callback value and logs captured telemetry context", async () => {
+    const aggregate = createSubscribeAggregator("ats", 2);
+    const opName = `OpName-${randomUUID()}`;
+
+    const result = await withLocalTelemetryContext(opName, async () => {
+      logProperty("Input", { ats: "greenhouse", id: "company" });
+      logProperty("Input", { full: true });
+      logCounter("CacheHit");
+      logCounter("CacheHit", 2);
+      aggregate({
+        tag: "greenhouse GET Jobs",
+        dense: { name: "GET Jobs", ats: "greenhouse", id: "company" },
+        metrics: { ms: 25 },
+        blob: { ignored: true },
+      });
+      return { total: 13, fresh: 9 };
+    });
+
+    assert.deepEqual(result, { total: 13, fresh: 9 });
+
+    const logText = await waitForLogText(opName);
+    assert.match(logText, new RegExp(`"name": "${opName}"`));
+    assert.match(logText, /"duration": \d+/);
+    assert.match(logText, /"CacheHit": 3/);
+    assert.match(logText, /"greenhouse GET Jobs": 1/);
+    assert.match(logText, /"full": true/);
+  });
+
+  test("withLocalTelemetryContext: logs captured telemetry context and rethrows callback errors", async () => {
+    const opName = `OpName-${randomUUID()}`;
+
+    await assert.rejects(
+      withLocalTelemetryContext(opName, async () => {
+        logProperty("Input", { ats: "greenhouse", id: "missing-company" });
+        throw new Error("Call failed");
+      }),
+      /Call failed/,
+    );
+
+    const logText = await waitForLogText(opName);
+    assert.match(logText, new RegExp(`"name": "${opName}"`));
+    assert.match(logText, /"duration": \d+/);
+    assert.match(logText, /"id": "missing-company"/);
+  });
+});

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -129,6 +129,7 @@ npm run cli -- playground
 ## Logs and output
 
 Run information is logged to the console. Detailed output is saved to `packages/cli/logs/app.log`.
+Commands that invoke backend code directly also write backend telemetry summaries to this log.
 Evaluation artifacts are organized under `logs/`:
 
 ```

--- a/packages/cli/src/portal/pFuncs.ts
+++ b/packages/cli/src/portal/pFuncs.ts
@@ -1,6 +1,7 @@
 import { llm } from "../../../backend/src/ai/llm.ts";
 import { ats as atsObj } from "../../../backend/src/ats/ats.ts";
 import { JOB_EXPIRY_MS } from "../../../backend/src/utils/constants.ts";
+import { withLocalTelemetryContext } from "../../../backend/src/utils/telemetry.ts";
 import { CommandError, type Bag } from "../types.ts";
 import type { ATS } from "./atsConsts.ts";
 import { llmActionTypes, type Context, type LLMAction } from "./pTypes.ts";
@@ -28,7 +29,9 @@ export function validateLLMAction(llmAction?: string): LLMAction {
  * @returns A company object from the ATS
  */
 export async function fetchCompany(ats: ATS, companyId: string) {
-  return await atsObj.getCompany({ id: companyId, ats }, true);
+  return await withLocalTelemetryContext("Portal.FetchCompany", async () => {
+    return await atsObj.getCompany({ id: companyId, ats }, true);
+  });
 }
 
 /**
@@ -40,24 +43,29 @@ export async function fetchCompany(ats: ATS, companyId: string) {
  * @throws CommandError when the company has no jobs.
  */
 export async function fetchJob(ats: ATS, companyId: string, jobId?: string) {
-  if (!jobId) {
-    const jobs = await atsObj.getJobs({ id: companyId, ats }, false);
+  return await withLocalTelemetryContext("Portal.FetchJob", async () => {
+    if (!jobId) {
+      const jobs = await atsObj.getJobs({ id: companyId, ats }, false);
 
-    if (!jobs.length) {
-      throw new CommandError(`No jobs available for ${ats} / ${companyId}`);
+      if (!jobs.length) {
+        throw new CommandError(`No jobs available for ${ats} / ${companyId}`);
+      }
+
+      const job = jobs[Math.floor(Math.random() * jobs.length)]!;
+
+      // If the ATS didn't support partial job fetching, we can skip the extra fetch
+      if (job.context) {
+        return job;
+      }
+
+      jobId = job.item.id;
     }
 
-    const job = jobs[Math.floor(Math.random() * jobs.length)]!;
-
-    // If the ATS didn't support partial job fetching, we can skip the extra fetch
-    if (job.context) {
-      return job;
-    }
-
-    jobId = job.item.id;
-  }
-
-  return await atsObj.getJob({ id: companyId, ats }, { id: jobId, companyId });
+    return await atsObj.getJob(
+      { id: companyId, ats },
+      { id: jobId, companyId },
+    );
+  });
 }
 
 /**
@@ -70,35 +78,39 @@ export async function fetchJobCounts(
   ats: ATS,
   companyId: string,
 ): Promise<{ total: number; fresh: number }> {
-  const jobs = await atsObj.getJobs({ id: companyId, ats }, false);
-  const expiryWindow = Date.now() - JOB_EXPIRY_MS;
-  const freshJobs = jobs.filter(
-    ({ item: { postTS } }) => postTS >= expiryWindow,
-  );
-  return { total: jobs.length, fresh: freshJobs.length };
+  return await withLocalTelemetryContext("Portal.FetchJobCounts", async () => {
+    const jobs = await atsObj.getJobs({ id: companyId, ats }, false);
+    const expiryWindow = Date.now() - JOB_EXPIRY_MS;
+    const freshJobs = jobs.filter(
+      ({ item: { postTS } }) => postTS >= expiryWindow,
+    );
+    return { total: jobs.length, fresh: freshJobs.length };
+  });
 }
 
 export async function infer(
   llmAction: LLMAction,
   arg: string | Context<Bag>,
 ): Promise<Bag> {
-  switch (llmAction) {
-    case "fillCompanyInfo":
-    case "fillJobInfo":
-      if (typeof arg === "string") {
-        throw new CommandError(`Expected Context<Bag> for ${llmAction}`);
+  return await withLocalTelemetryContext("Portal.Infer", async () => {
+    switch (llmAction) {
+      case "fillCompanyInfo":
+      case "fillJobInfo":
+        if (typeof arg === "string") {
+          throw new CommandError(`Expected Context<Bag> for ${llmAction}`);
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await llm[llmAction](arg as Context<any>);
+        return arg.item;
+      case "isGeneralApplication":
+      case "extractLocation":
+      case "interpretFilters": {
+        if (typeof arg === "object") {
+          throw new CommandError(`Expected string argument for ${llmAction}`);
+        }
+        const result = await llm[llmAction](arg);
+        return typeof result === "boolean" ? { bool: result } : (result as Bag);
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await llm[llmAction](arg as Context<any>);
-      return arg.item;
-    case "isGeneralApplication":
-    case "extractLocation":
-    case "interpretFilters": {
-      if (typeof arg === "object") {
-        throw new CommandError(`Expected string argument for ${llmAction}`);
-      }
-      const result = await llm[llmAction](arg);
-      return typeof result === "boolean" ? { bool: result } : (result as Bag);
     }
-  }
+  });
 }

--- a/packages/cli/test/portal/pFuncs.test.ts
+++ b/packages/cli/test/portal/pFuncs.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { after, suite, test } from "node:test";
+import timers from "node:timers/promises";
+import { fetchJobCounts } from "../../src/portal/pFuncs.ts";
+import { afterReset, logBasePath, mockFetch } from "../setup.ts";
+
+after(afterReset);
+
+const updatedAt = new Date().toISOString();
+
+async function waitForLogText(expected: string): Promise<string> {
+  const logFile = path.join(logBasePath, "test.log");
+  const start = Date.now();
+  let text = "";
+
+  while (Date.now() - start < 500) {
+    text = await readFile(logFile, "utf8").catch(() => "");
+
+    if (text.includes(expected)) {
+      return text;
+    }
+
+    await timers.setTimeout(10);
+  }
+
+  return text;
+}
+
+function jobsResponse(companyId: string) {
+  return new Response(
+    JSON.stringify({
+      jobs: [
+        {
+          id: 101,
+          internal_job_id: 1001,
+          title: "SOFTWARE ENGINEER",
+          updated_at: updatedAt,
+          requisition_id: "REQ-1",
+          location: { name: "Remote" },
+          absolute_url: `https://boards.example/${companyId}/101`,
+        },
+        {
+          id: 102,
+          internal_job_id: 1002,
+          title: "DESIGNER",
+          updated_at: "2020-01-01T00:00:00.000Z",
+          requisition_id: "REQ-2",
+          location: { name: "Remote" },
+          absolute_url: `https://boards.example/${companyId}/102`,
+        },
+      ],
+      meta: { total: 2 },
+    }),
+    {
+      headers: {
+        "content-type": "application/json",
+        etag: 'W/"portal-log-test"',
+      },
+    },
+  );
+}
+
+suite("portal pFuncs", () => {
+  test("fetchJobCounts writes backend ATS telemetry to the CLI log file", async () => {
+    const companyId = `portal-log-${randomUUID()}`;
+    const fetchMock = mockFetch(async () => jobsResponse(companyId));
+
+    const result = await fetchJobCounts("greenhouse", companyId);
+
+    assert.deepEqual(result, { total: 2, fresh: 1 });
+    assert.equal(fetchMock.callCount(), 1);
+
+    const logText = await waitForLogText(companyId);
+    assert.match(logText, /"name": "Portal\.FetchJobCounts"/);
+    assert.match(logText, /"greenhouse GET JobsBasic": 1/);
+    assert.match(logText, new RegExp(`"id": "${companyId}"`));
+    assert.match(logText, /"ats": "greenhouse"/);
+    assert.match(logText, /"metrics": \{\s+"ms": \d+\s+\}/);
+  });
+});

--- a/packages/cli/test/portal/pFuncs.test.ts
+++ b/packages/cli/test/portal/pFuncs.test.ts
@@ -10,14 +10,19 @@ import { afterReset, logBasePath, mockFetch } from "../setup.ts";
 after(afterReset);
 
 const updatedAt = new Date().toISOString();
+const logFile = path.join(logBasePath, "test.log");
 
-async function waitForLogText(expected: string): Promise<string> {
-  const logFile = path.join(logBasePath, "test.log");
+async function waitForLogText(
+  expected: string,
+  startPosition: number,
+): Promise<string> {
   const start = Date.now();
   let text = "";
 
   while (Date.now() - start < 500) {
-    text = await readFile(logFile, "utf8").catch(() => "");
+    text = (await readFile(logFile, "utf8").catch(() => "")).slice(
+      startPosition,
+    );
 
     if (text.includes(expected)) {
       return text;
@@ -67,17 +72,19 @@ suite("portal pFuncs", () => {
   test("fetchJobCounts writes backend ATS telemetry to the CLI log file", async () => {
     const companyId = `portal-log-${randomUUID()}`;
     const fetchMock = mockFetch(async () => jobsResponse(companyId));
+    const logStartPosition = (await readFile(logFile, "utf8").catch(() => ""))
+      .length;
 
     const result = await fetchJobCounts("greenhouse", companyId);
 
     assert.deepEqual(result, { total: 2, fresh: 1 });
     assert.equal(fetchMock.callCount(), 1);
 
-    const logText = await waitForLogText(companyId);
+    const logText = await waitForLogText(companyId, logStartPosition);
     assert.match(logText, /"name": "Portal\.FetchJobCounts"/);
     assert.match(logText, /"greenhouse GET JobsBasic": 1/);
     assert.match(logText, new RegExp(`"id": "${companyId}"`));
     assert.match(logText, /"ats": "greenhouse"/);
-    assert.match(logText, /"metrics": \{\s+"ms": \d+\s+\}/);
+    assert.match(logText, /"metrics": \{\s+"ms": \d+,\s+"bytes": \d+\s+\}/);
   });
 });


### PR DESCRIPTION
Backend

- (infra): Log content length of ATS responses
- (infra): Cleanup/prep work for etags
- (infra): Add unit tests for DB container classes

CLI (infra)

- When taking actions that use backend code directly, route the backend logging to the CLI log file