### PR TITLE
Add ATS ETag Caching

### DIFF
--- a/packages/backend/src/ats/ATSInterface.ts
+++ b/packages/backend/src/ats/ATSInterface.ts
@@ -1,15 +1,38 @@
 import type { Company, CompanyKey, Job, JobKey } from "../models/models.ts";
 import type { Context } from "../types/types.ts";
 
+export type Tags<T> =
+  | { stable: true }
+  | { stable: false; data: T; etag?: string };
+
 export abstract class ATSInterface {
+  /** True if this ATS support ETag caching */
+  abstract supportsETag(key: CompanyKey): boolean;
+
   /** Get company information from the ATS */
   abstract getCompany(key: CompanyKey): Promise<Company>;
 
   /**
    * Get all of a company's jobs from the ATS.
-   * @param meta If true and the ATS supports it, only fetch metadata (no context, item valid but not fully defined)
+   * @param key The company identifier
+   * @param onlyMetadata If true and the ATS supports it, only fetch metadata (no context, item valid but not fully defined)
    */
-  abstract getJobs(key: CompanyKey, meta?: boolean): Promise<Context<Job>[]>;
+  abstract getJobs(
+    key: CompanyKey,
+    onlyMetadata?: boolean,
+  ): Promise<Context<Job>[]>;
+
+  /**
+   * Get all of a company's jobs from the ATS using ETag caching, if supported.
+   * @param key The company identifier
+   * @param onlyMetadata If true and the ATS supports it, only fetch metadata (no context, item valid but not fully defined)
+   * @param etag If truthy, send this etag value to the ATS
+   */
+  abstract getJobsETag(
+    key: CompanyKey,
+    etag?: string,
+    onlyMetadata?: boolean,
+  ): Promise<Tags<Context<Job>[]>>;
 
   /** Get detailed information for an example job */
   abstract getExampleJob(key: CompanyKey): Promise<Context<Job> | undefined>;

--- a/packages/backend/src/ats/ATSInterface.ts
+++ b/packages/backend/src/ats/ATSInterface.ts
@@ -15,23 +15,20 @@ export abstract class ATSInterface {
   /**
    * Get all of a company's jobs from the ATS.
    * @param key The company identifier
-   * @param onlyMetadata If true and the ATS supports it, only fetch metadata (no context, item valid but not fully defined)
+   * @param meta If true and the ATS supports it, only fetch metadata (no context, item valid but not fully defined)
    */
-  abstract getJobs(
-    key: CompanyKey,
-    onlyMetadata?: boolean,
-  ): Promise<Context<Job>[]>;
+  abstract getJobs(key: CompanyKey, meta?: boolean): Promise<Context<Job>[]>;
 
   /**
    * Get all of a company's jobs from the ATS using ETag caching, if supported.
    * @param key The company identifier
-   * @param onlyMetadata If true and the ATS supports it, only fetch metadata (no context, item valid but not fully defined)
+   * @param meta If true and the ATS supports it, only fetch metadata (no context, item valid but not fully defined)
    * @param etag If truthy, send this etag value to the ATS
    */
   abstract getJobsETag(
     key: CompanyKey,
     etag?: string,
-    onlyMetadata?: boolean,
+    meta?: boolean,
   ): Promise<Tags<Context<Job>[]>>;
 
   /** Get detailed information for an example job */

--- a/packages/backend/src/ats/ashby.ts
+++ b/packages/backend/src/ats/ashby.ts
@@ -1,7 +1,6 @@
 import { config } from "../config.ts";
-import type { Company, CompanyKey, Job, JobKey } from "../models/models.ts";
+import type { CompanyKey, JobKey } from "../models/models.ts";
 import { logError } from "../telemetry/telemetry.ts";
-import type { Context } from "../types/types.ts";
 import { AppError } from "../utils/AppError.ts";
 import type { CompanyResult } from "./ashby/companyResult.ts";
 import { formatCompany, formatJob } from "./ashbyFormat.ts";
@@ -10,21 +9,28 @@ import { ATSBase } from "./atsBase.ts";
 const NAME = "ashby";
 export class Ashby extends ATSBase {
   constructor() {
-    super(NAME, config.ASHBY_URL);
+    super(NAME, config.ASHBY_URL, false);
   }
 
-  async getCompany({ id }: CompanyKey): Promise<Company> {
+  async getCompany({ id }: CompanyKey) {
     await this.#validateKey(id);
     return Promise.resolve(formatCompany(id));
   }
 
-  async getJobs({ id }: CompanyKey): Promise<Context<Job>[]> {
-    const { jobs } = await this.#fetchCompany(id);
+  async getJobs({ id }: CompanyKey) {
+    // Note: Metadata unsupported
+    const { jobs } = await this.#fetchJobs(id);
     return jobs.map((job) => formatJob(id, job));
   }
 
-  async getExampleJob({ id }: CompanyKey): Promise<Context<Job> | undefined> {
-    const { jobs } = await this.#fetchCompany(id);
+  async getJobsETag(key: CompanyKey) {
+    // Note: Metadata and ETag unsupported
+    const res = await this.getJobs(key);
+    return { stable: false, data: res };
+  }
+
+  async getExampleJob({ id }: CompanyKey) {
+    const { jobs } = await this.#fetchJobs(id);
 
     if (!jobs.length) return undefined;
 
@@ -33,13 +39,13 @@ export class Ashby extends ATSBase {
     return formatJob(id, job);
   }
 
-  async getSpecificJob({ id, companyId }: JobKey): Promise<Context<Job>> {
+  async getSpecificJob({ id, companyId }: JobKey) {
     // Ashby ALWAYS returns the all jobs, so we have to fetch them all and find the right one
     // This is inefficient and should be avoided
     // We log an error so we can track if this accidentally happens in production
     logError("Ashby.getSpecificJob: This should never be called when deployed");
 
-    const { jobs } = await this.#fetchCompany(companyId);
+    const { jobs } = await this.#fetchJobs(companyId);
     const job = jobs.find((job) => job.id === id);
 
     if (!job) {
@@ -53,7 +59,7 @@ export class Ashby extends ATSBase {
     return this.httpCall<CompanyResult>("Company", id, "");
   }
 
-  async #fetchCompany(id: string): Promise<CompanyResult> {
+  async #fetchJobs(id: string) {
     const route = "?includeCompensation=true";
     return this.httpCall<CompanyResult>("Company", id, route);
   }

--- a/packages/backend/src/ats/ats.ts
+++ b/packages/backend/src/ats/ats.ts
@@ -20,12 +20,12 @@ class ATSConnector extends ATSInterface {
     return this.#atsEndpoints[key.ats].getCompany(key);
   }
 
-  getJobs(key: CompanyKey, onlyMetadata?: boolean) {
-    return this.#atsEndpoints[key.ats].getJobs(key, onlyMetadata);
+  getJobs(key: CompanyKey, meta?: boolean) {
+    return this.#atsEndpoints[key.ats].getJobs(key, meta);
   }
 
-  getJobsETag(key: CompanyKey, etag?: string, onlyMetadata?: boolean) {
-    return this.#atsEndpoints[key.ats].getJobsETag(key, etag, onlyMetadata);
+  getJobsETag(key: CompanyKey, etag?: string, meta?: boolean) {
+    return this.#atsEndpoints[key.ats].getJobsETag(key, etag, meta);
   }
 
   getExampleJob(key: CompanyKey) {

--- a/packages/backend/src/ats/ats.ts
+++ b/packages/backend/src/ats/ats.ts
@@ -12,12 +12,20 @@ class ATSConnector extends ATSInterface {
     ashby: new Ashby(),
   };
 
+  supportsETag(key: CompanyKey) {
+    return this.#atsEndpoints[key.ats].supportsETag();
+  }
+
   getCompany(key: CompanyKey) {
     return this.#atsEndpoints[key.ats].getCompany(key);
   }
 
-  getJobs(key: CompanyKey, meta?: boolean) {
-    return this.#atsEndpoints[key.ats].getJobs(key, meta);
+  getJobs(key: CompanyKey, onlyMetadata?: boolean) {
+    return this.#atsEndpoints[key.ats].getJobs(key, onlyMetadata);
+  }
+
+  getJobsETag(key: CompanyKey, etag?: string, onlyMetadata?: boolean) {
+    return this.#atsEndpoints[key.ats].getJobsETag(key, etag, onlyMetadata);
   }
 
   getExampleJob(key: CompanyKey) {

--- a/packages/backend/src/ats/atsBase.ts
+++ b/packages/backend/src/ats/atsBase.ts
@@ -93,7 +93,6 @@ export abstract class ATSBase extends ATSInterface {
     init?: RequestInit,
   ) {
     const start = Date.now();
-
     let logStatus: StatusResponse;
     let bytes = -1;
 
@@ -103,18 +102,11 @@ export abstract class ATSBase extends ATSInterface {
         signal: AbortSignal.timeout(15_000),
       });
 
-      const { status, statusText, ok, headers } = response;
+      const { status, statusText } = response;
       logStatus = { status, statusText };
       bytes = await this.#getContentLength(response);
 
-      if (status === 404) {
-        throw new AppError(`${this.#ats} / ${id}: Not Found`, 404);
-      } else if (!ok) {
-        throw new AppError(`${this.#ats} / ${id}: Request Failed`, 500);
-      }
-
-      const data = (await response.json()) as T;
-      return { data, status, headers };
+      return this.#processResponse<T>(id, response);
     } catch (error) {
       logStatus = this.#errorToStatus(error);
 
@@ -147,6 +139,24 @@ export abstract class ATSBase extends ATSInterface {
       logError(error);
       return -1;
     }
+  }
+
+  async #processResponse<T>(id: string, res: Response) {
+    const { status, ok, headers } = res;
+
+    if (!ok) {
+      switch (status) {
+        case 304:
+          return { data: undefined as T, status, headers };
+        case 404:
+          throw new AppError(`${this.#ats} / ${id}: Not Found`, 404);
+        default:
+          throw new AppError(`${this.#ats} / ${id}: Request Failed`, 500);
+      }
+    }
+
+    const data = (await res.json()) as T;
+    return { data, status, headers };
   }
 
   #errorToStatus(error: unknown): StatusResponse {

--- a/packages/backend/src/ats/atsBase.ts
+++ b/packages/backend/src/ats/atsBase.ts
@@ -2,7 +2,7 @@ import type { ATS } from "../models/models.ts";
 import { createSubscribeAggregator, logError } from "../telemetry/telemetry.ts";
 import type { Bag } from "../types/types.ts";
 import { AppError } from "../utils/AppError.ts";
-import { ATSInterface } from "./ATSInterface.ts";
+import { ATSInterface, type Tags } from "./ATSInterface.ts";
 
 type StatusResponse = { status: number; statusText: string };
 
@@ -13,11 +13,27 @@ type StatusResponse = { status: number; statusText: string };
 export abstract class ATSBase extends ATSInterface {
   readonly #ats: ATS;
   readonly #baseUrl: string;
+  readonly #supportsETag: boolean;
 
-  constructor(ats: ATS, baseUrl: string) {
+  constructor(ats: ATS, baseUrl: string, supportsETag: boolean) {
     super();
     this.#ats = ats;
     this.#baseUrl = baseUrl;
+    this.#supportsETag = supportsETag;
+  }
+
+  supportsETag(): boolean {
+    return this.#supportsETag;
+  }
+
+  protected formatTags<IN, OUT>(
+    id: string,
+    tags: Tags<IN>,
+    fmt: (id: string, x: IN) => OUT,
+  ): Tags<OUT> {
+    if (tags.stable) return tags;
+    const { stable, data, etag } = tags;
+    return { stable, data: fmt(id, data), etag };
   }
 
   /**
@@ -33,28 +49,72 @@ export abstract class ATSBase extends ATSInterface {
     id: string,
     url: string,
   ): Promise<T> {
+    const { data } = await this.#httpCallInternal<T>(name, id, url);
+    return data;
+  }
+
+  /**
+   * Makes an HTTP GET request to the ATS API
+   * @param name Name of the operation for logging
+   * @param id Company identifier
+   * @param url API endpoint URL
+   * @param etag If truthy, send this etag value to the ATS
+   * @returns API response data, wrapped in a Tag with etag metadata
+   * @throws AppError for 404 or other error responses
+   */
+  protected async httpCallETag<T>(
+    name: string,
+    id: string,
+    url: string,
+    etag?: string,
+  ): Promise<Tags<T>> {
+    const init: RequestInit = !etag
+      ? {}
+      : {
+          // Use force-cache to keep Node's fetch from adding headers that conflict with Lever's ETag behavior.
+          cache: "force-cache",
+          headers: { "If-None-Match": etag },
+        };
+
+    const res = await this.#httpCallInternal<T>(name, id, url, init);
+    const { data, status, headers } = res;
+
+    if (etag && status === 304) {
+      return { stable: true };
+    }
+
+    return { stable: false, data, etag: headers.get("etag") ?? undefined };
+  }
+
+  async #httpCallInternal<T>(
+    name: string,
+    id: string,
+    url: string,
+    init?: RequestInit,
+  ) {
     const start = Date.now();
+
     let logStatus: StatusResponse;
     let bytes = -1;
 
     try {
       const response = await fetch(`${this.#baseUrl}/${id}/${url}`, {
+        ...init,
         signal: AbortSignal.timeout(15_000),
       });
 
-      const { status, statusText, ok } = response;
+      const { status, statusText, ok, headers } = response;
       logStatus = { status, statusText };
       bytes = await this.#getContentLength(response);
 
-      if (!ok) {
-        if (status === 404) {
-          throw new AppError(`${this.#ats} / ${id}: Not Found`, 404);
-        }
-
+      if (status === 404) {
+        throw new AppError(`${this.#ats} / ${id}: Not Found`, 404);
+      } else if (!ok) {
         throw new AppError(`${this.#ats} / ${id}: Request Failed`, 500);
       }
 
-      return (await response.json()) as T;
+      const data = (await response.json()) as T;
+      return { data, status, headers };
     } catch (error) {
       logStatus = this.#errorToStatus(error);
 

--- a/packages/backend/src/ats/greenhouse.ts
+++ b/packages/backend/src/ats/greenhouse.ts
@@ -26,8 +26,8 @@ export class Greenhouse extends ATSBase {
     return formatCompany(id, companyResult);
   }
 
-  async getJobs({ id }: CompanyKey, onlyMetadata?: boolean) {
-    if (onlyMetadata) {
+  async getJobs({ id }: CompanyKey, meta?: boolean) {
+    if (meta) {
       const res = await this.#fetchJobsBasic(id);
       return formatJobsBasic(id, res);
     } else {
@@ -36,8 +36,8 @@ export class Greenhouse extends ATSBase {
     }
   }
 
-  async getJobsETag({ id }: CompanyKey, etag?: string, onlyMetadata?: boolean) {
-    if (onlyMetadata) {
+  async getJobsETag({ id }: CompanyKey, etag?: string, meta?: boolean) {
+    if (meta) {
       const res = await this.#fetchJobsBasicETag(id, etag);
       return this.formatTags(id, res, formatJobsBasic);
     } else {

--- a/packages/backend/src/ats/greenhouse.ts
+++ b/packages/backend/src/ats/greenhouse.ts
@@ -1,6 +1,5 @@
 import { config } from "../config.ts";
-import type { Company, CompanyKey, Job, JobKey } from "../models/models.ts";
-import type { Context } from "../types/types.ts";
+import type { CompanyKey, JobKey } from "../models/models.ts";
 import { ATSBase } from "./atsBase.ts";
 import {
   formatCompany,
@@ -19,16 +18,16 @@ import {
  */
 export class Greenhouse extends ATSBase {
   constructor() {
-    super("greenhouse", config.GREENHOUSE_URL);
+    super("greenhouse", config.GREENHOUSE_URL, true);
   }
 
-  async getCompany({ id }: CompanyKey): Promise<Company> {
+  async getCompany({ id }: CompanyKey) {
     const companyResult = await this.#fetchCompany(id);
     return formatCompany(id, companyResult);
   }
 
-  async getJobs({ id }: CompanyKey, meta = false): Promise<Context<Job>[]> {
-    if (meta) {
+  async getJobs({ id }: CompanyKey, onlyMetadata?: boolean) {
+    if (onlyMetadata) {
       const res = await this.#fetchJobsBasic(id);
       return formatJobsBasic(id, res);
     } else {
@@ -37,7 +36,17 @@ export class Greenhouse extends ATSBase {
     }
   }
 
-  async getExampleJob({ id }: CompanyKey): Promise<Context<Job> | undefined> {
+  async getJobsETag({ id }: CompanyKey, etag?: string, onlyMetadata?: boolean) {
+    if (onlyMetadata) {
+      const res = await this.#fetchJobsBasicETag(id, etag);
+      return this.formatTags(id, res, formatJobsBasic);
+    } else {
+      const res = await this.#fetchJobsETag(id, etag);
+      return this.formatTags(id, res, formatJobs);
+    }
+  }
+
+  async getExampleJob({ id }: CompanyKey) {
     const { jobs } = await this.#fetchJobsBasic(id);
 
     if (!jobs.length) return undefined;
@@ -47,7 +56,7 @@ export class Greenhouse extends ATSBase {
     return await this.getSpecificJob({ id: jobId, companyId: id });
   }
 
-  async getSpecificJob({ id, companyId }: JobKey): Promise<Context<Job>> {
+  async getSpecificJob({ id, companyId }: JobKey) {
     const response = await this.#fetchJob(companyId, id);
     return formatJob(companyId, response);
   }
@@ -66,5 +75,14 @@ export class Greenhouse extends ATSBase {
 
   async #fetchJobsBasic(id: string) {
     return this.httpCall<JobsResultBasic>("JobsBasic", id, "/jobs");
+  }
+
+  async #fetchJobsETag(id: string, etag?: string) {
+    const route = "/jobs?content=true";
+    return this.httpCallETag<JobsResult>("Jobs", id, route, etag);
+  }
+
+  async #fetchJobsBasicETag(id: string, etag?: string) {
+    return this.httpCallETag<JobsResultBasic>("JobsBasic", id, "/jobs", etag);
   }
 }

--- a/packages/backend/src/ats/lever.ts
+++ b/packages/backend/src/ats/lever.ts
@@ -1,7 +1,6 @@
 import { config } from "../config.ts";
-import type { Company, CompanyKey, Job, JobKey } from "../models/models.ts";
+import type { CompanyKey, JobKey } from "../models/models.ts";
 import { logError } from "../telemetry/telemetry.ts";
-import type { Context } from "../types/types.ts";
 import { AppError } from "../utils/AppError.ts";
 import { ATSBase } from "./atsBase.ts";
 import {
@@ -17,30 +16,32 @@ import {
  */
 export class Lever extends ATSBase {
   constructor() {
-    super("lever", config.LEVER_URL);
+    super("lever", config.LEVER_URL, true);
   }
 
-  async getCompany({ id }: CompanyKey): Promise<Company> {
+  async getCompany({ id }: CompanyKey) {
     await this.#validateKey(id);
     return Promise.resolve(formatCompany(id));
   }
 
-  async getJobs({ id }: CompanyKey): Promise<Context<Job>[]> {
-    const jobs = await this.#fetchJobs(id);
-    return formatJobs(id, jobs);
+  async getJobs({ id }: CompanyKey) {
+    // Note: Metadata unsupported
+    const res = await this.#fetchJobs(id);
+    return formatJobs(id, res);
   }
 
-  async getExampleJob({ id }: CompanyKey): Promise<Context<Job> | undefined> {
-    const jobs = await this.#fetchJobs(id);
-
-    if (!jobs.length) return undefined;
-
-    const idx = Math.floor(Math.random() * jobs.length);
-    const job = jobs[idx]!;
-    return formatJob(id, job);
+  async getJobsETag({ id }: CompanyKey, etag?: string) {
+    // Note: Metadata unsupported
+    const res = await this.#fetchJobsETag(id, etag);
+    return this.formatTags(id, res, formatJobs);
   }
 
-  async getSpecificJob({ id, companyId }: JobKey): Promise<Context<Job>> {
+  async getExampleJob({ id }: CompanyKey) {
+    const job = await this.#fetchSingleJob(id);
+    return job ? formatJob(id, job) : undefined;
+  }
+
+  async getSpecificJob({ id, companyId }: JobKey) {
     // Lever ALWAYS returns the top X jobs, so we have to fetch them all and find the right one
     // This is inefficient and should be avoided
     // We log an error so we can track if this accidentally happens in production
@@ -61,8 +62,19 @@ export class Lever extends ATSBase {
     return this.httpCall<JobResult[]>("Jobs", id, query);
   }
 
+  async #fetchSingleJob(id: string) {
+    const query = "?mode=json&limit=1";
+    const jobs = await this.httpCall<JobResult[]>("Jobs", id, query);
+    return jobs[0];
+  }
+
   async #fetchJobs(id: string) {
     const query = "?mode=json";
     return this.httpCall<JobResult[]>("Jobs", id, query);
+  }
+
+  async #fetchJobsETag(id: string, etag?: string) {
+    const query = "?mode=json";
+    return this.httpCallETag<JobResult[]>("Jobs", id, query, etag);
   }
 }

--- a/packages/backend/src/controllers/company.ts
+++ b/packages/backend/src/controllers/company.ts
@@ -59,6 +59,7 @@ export async function removeCompany(key: CompanyKey) {
   const [, idRes] = await Promise.all([
     db.company.remove(key),
     db.job.removeAll(companyId),
+    db.eTag.deleteAll(key),
   ]);
 
   if (idRes.length) {

--- a/packages/backend/src/db/ETagContainer.ts
+++ b/packages/backend/src/db/ETagContainer.ts
@@ -1,0 +1,52 @@
+import { batch } from "dry-utils-async";
+import { Container, type ContainerOptions } from "dry-utils-cosmosdb";
+import type { CompanyKey, ETag } from "../models/models.ts";
+import { normalizeId } from "./utils.ts";
+
+const ContainerName = "etag";
+
+/** Point-read map between ATS resources and their latest ETags. */
+export class ETagContainer extends Container<ETag> {
+  /** Returns the Cosmos DB initialization options for this container. */
+  static ContainerOptions(): ContainerOptions {
+    return {
+      name: ContainerName,
+      partitionKey: "atsCompany",
+      ttlSeconds: 30 * 24 * 60 * 60,
+      indexExclusions: "all",
+    };
+  }
+
+  /** Wraps an initialized ETag container. */
+  constructor(container: Container<ETag>) {
+    super(ContainerName, container.container);
+  }
+
+  /** Gets the latest saved ETag for an ATS resource. */
+  async get(id: string, key: CompanyKey) {
+    const result = await this.getItem(normalizeId(id), this.#asPKey(key));
+    return result?.etag;
+  }
+
+  /** Saves the latest ETag for an ATS resource. */
+  async set(id: string, key: CompanyKey, etag: string) {
+    await this.upsertItem({
+      id: normalizeId(id),
+      atsCompany: this.#asPKey(key),
+      etag,
+    });
+  }
+
+  /** Removes all etags for a company. */
+  async deleteAll(key: CompanyKey) {
+    const pKey = this.#asPKey(key);
+    const ids = await this.getIdsByPartitionKey(pKey);
+    if (!ids.length) return [];
+
+    return await batch("DeleteAllETag", ids, (id) => this.deleteItem(id, pKey));
+  }
+
+  #asPKey({ ats, id }: CompanyKey) {
+    return `${ats}+${id}`;
+  }
+}

--- a/packages/backend/src/db/JobContainer.ts
+++ b/packages/backend/src/db/JobContainer.ts
@@ -1,5 +1,5 @@
 import { batch } from "dry-utils-async";
-import { Container, type ContainerOptions } from "dry-utils-cosmosdb";
+import { Container, Query, type ContainerOptions } from "dry-utils-cosmosdb";
 import { JobFamily, Presence } from "../models/enums.ts";
 import type { Job, JobKey, Metadata } from "../models/models.ts";
 import { MS_PER_DAY } from "../utils/constants.ts";
@@ -42,6 +42,16 @@ export class JobContainer extends Container<Job> {
       "SELECT c.id, c._ts FROM c",
       { partitionKey: companyId },
     );
+  }
+
+  /** Gets job IDs for a company with a post timestamp older than the cutoff. */
+  async getExpiredIds(companyId: string, cutoffMS: number) {
+    const result = await this.query<{ id: string }>(
+      new Query("ID", ["postTS", "<", cutoffMS]),
+      { partitionKey: companyId },
+    );
+
+    return result.map(({ id }) => id);
   }
 
   /** Gets IDs of companies that have jobs. */

--- a/packages/backend/src/db/db.ts
+++ b/packages/backend/src/db/db.ts
@@ -7,6 +7,7 @@ import {
 import { config } from "../config.ts";
 import type {
   Company,
+  ETag,
   IgnoreJob,
   Job,
   Location,
@@ -18,6 +19,7 @@ import {
   subscribeLog,
 } from "../telemetry/telemetry.ts";
 import { CompanyContainer } from "./CompanyContainer.ts";
+import { ETagContainer } from "./ETagContainer.ts";
 import { IgnoreJobContainer } from "./IgnoreJobContainer.ts";
 import { JobContainer } from "./JobContainer.ts";
 
@@ -33,6 +35,7 @@ class DB {
   #ignoreJob: IgnoreJobContainer | undefined;
   #metadata: Container<Metadata> | undefined;
   #locationCache: Container<Location> | undefined;
+  #eTag: ETagContainer | undefined;
 
   get company() {
     return this.#validate(this.#company);
@@ -52,6 +55,10 @@ class DB {
 
   get locationCache() {
     return this.#validate(this.#locationCache);
+  }
+
+  get eTag() {
+    return this.#validate(this.#eTag);
   }
 
   /**
@@ -85,6 +92,7 @@ class DB {
           partitionKey: "pKey",
           indexExclusions: "all",
         },
+        ETagContainer.ContainerOptions(),
       ],
     });
 
@@ -97,6 +105,7 @@ class DB {
     );
     this.#metadata = containers["metadata"] as Container<Metadata>;
     this.#locationCache = containers["locationCache"];
+    this.#eTag = new ETagContainer(containers["etag"] as Container<ETag>);
   }
 
   #validate<T>(container: T | undefined): T {

--- a/packages/backend/src/models/models.ts
+++ b/packages/backend/src/models/models.ts
@@ -78,6 +78,19 @@ export interface IgnoreJob {
 }
 
 /**
+ * Latest ETag for an ATS resource.
+ * - id: The workflow path assuming responsibility
+ * - atsCompany: `${ats}+${companyId}`
+ * - Index: Point reads only
+ * - TTL: 30 Days
+ */
+export interface ETag {
+  id: string;
+  atsCompany: string;
+  etag: string;
+}
+
+/**
  * Aggregated metadata for other containers. Cached in the backend service.
  * - id: The type of metadata
  * - pKey: id

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -41,6 +41,7 @@ export async function refreshJobsForCompany(
 
   if (atsTags.stable) {
     logProperty("ATS_Jobs_Stable", true);
+    await removeExpiredJobs(companyId);
     return;
   }
 
@@ -78,6 +79,17 @@ export async function refreshJobsForCompany(
       add.map((job) => [key, job]),
       setETagCallback(etagId, key, etag),
     );
+  }
+}
+
+async function removeExpiredJobs(companyId: string) {
+  const expiryWindow = Date.now() - JOB_EXPIRY_MS;
+  const expiredIds = await db.job.getExpiredIds(companyId, expiryWindow);
+
+  logProperty("Saved_Jobs_Expired", expiredIds.length);
+
+  if (expiredIds.length) {
+    await db.job.removeMany(expiredIds, companyId);
   }
 }
 

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -8,6 +8,7 @@ import { db } from "../db/db.ts";
 import type { CompanyKey, Job } from "../models/models.ts";
 import { logProperty } from "../telemetry/telemetry.ts";
 import type { Context } from "../types/types.ts";
+import { AppError } from "../utils/AppError.ts";
 import { AsyncQueue, type OnGroupEnd } from "../utils/asyncQueue.ts";
 import { JOB_EXPIRY_MS } from "../utils/constants.ts";
 
@@ -178,7 +179,9 @@ async function refreshJobInfo([companyKey, job]: [CompanyKey, Context<Job>]) {
 
   // Do not add a job that failed to extract facets
   if (!success) {
-    return;
+    throw new AppError(
+      `${companyKey.ats}/${companyKey.id}/${job.item.id}: Extraction Failure`,
+    );
   }
 
   // This is a stopgap until we can add better US-only filters prior to main LLM processing.

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -54,6 +54,7 @@ export async function refreshJobsForCompany(
   ]);
 
   const [add, remove] = await groupAtsJobs(key, atsJobs, currentIds, ignoreIds);
+  const onJobsProcessed = createETagCallback(etagId, key, newEtag);
 
   if (remove.length) {
     await db.job.removeMany(remove, companyId);
@@ -77,8 +78,10 @@ export async function refreshJobsForCompany(
 
     jobInfoQueue.add(
       add.map((job) => [key, job]),
-      setETagCallback(etagId, key, newEtag),
+      onJobsProcessed,
     );
+  } else {
+    await onJobsProcessed?.(false);
   }
 }
 
@@ -203,7 +206,7 @@ async function getETag(
   return db.eTag.get(id, key);
 }
 
-function setETagCallback(
+function createETagCallback(
   id: string,
   key: CompanyKey,
   etag?: string,

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -45,7 +45,7 @@ export async function refreshJobsForCompany(
     return;
   }
 
-  const atsJobs = atsTags.data;
+  const { data: atsJobs, etag: newEtag } = atsTags;
   logProperty("ATS_Jobs_All", atsJobs.length);
 
   const [currentIds, ignoreIds] = await Promise.all([
@@ -77,7 +77,7 @@ export async function refreshJobsForCompany(
 
     jobInfoQueue.add(
       add.map((job) => [key, job]),
-      setETagCallback(etagId, key, etag),
+      setETagCallback(etagId, key, newEtag),
     );
   }
 }

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -18,7 +18,7 @@ const jobInfoQueue = new AsyncQueue("RefreshJobInfo", refreshJobInfo, {
 
 /**
  * Refreshes jobs for a specific company by synchronizing with ATS
- * @param key - Company identifier and optional timestamp to replace older jobs
+ * @param key Company identifier and optional timestamp to replace older jobs
  * @returns Promise resolving when jobs are refreshed
  */
 export async function refreshJobsForCompany(
@@ -30,7 +30,10 @@ export async function refreshJobsForCompany(
   // If the company is not in the quick ref map, then it has 0 jobs on the board
   const exists = (await getCompanyQuickRef(companyId)) != null;
   const etagId = `RefreshJobsForCompany_${exists}`;
-  const etag = await getETag(etagId, key);
+
+  // Get the saved etag, unless we are doing forced reprocessing
+  const etag =
+    key.replaceJobsOlderThan == null ? await getETag(etagId, key) : undefined;
 
   // Use the ETag caching flow
   // Ask for meta if the company exists. Otherwise assume newly added company and get full job data for all jobs.

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -8,7 +8,7 @@ import { db } from "../db/db.ts";
 import type { CompanyKey, Job } from "../models/models.ts";
 import { logProperty } from "../telemetry/telemetry.ts";
 import type { Context } from "../types/types.ts";
-import { AsyncQueue } from "../utils/asyncQueue.ts";
+import { AsyncQueue, type OnGroupEnd } from "../utils/asyncQueue.ts";
 import { JOB_EXPIRY_MS } from "../utils/constants.ts";
 
 const jobInfoQueue = new AsyncQueue("RefreshJobInfo", refreshJobInfo, {
@@ -29,9 +29,19 @@ export async function refreshJobsForCompany(
 
   // If the company is not in the quick ref map, then it has 0 jobs on the board
   const exists = (await getCompanyQuickRef(companyId)) != null;
+  const etagId = `RefreshJobsForCompany_${exists}`;
+  const etag = await getETag(etagId, key);
 
+  // Use the ETag caching flow
   // Ask for meta if the company exists. Otherwise assume newly added company and get full job data for all jobs.
-  const atsJobs = await ats.getJobs(key, exists);
+  const atsTags = await ats.getJobsETag(key, etag, exists);
+
+  if (atsTags.stable) {
+    logProperty("ATS_Jobs_Stable", true);
+    return;
+  }
+
+  const atsJobs = atsTags.data;
   logProperty("ATS_Jobs_All", atsJobs.length);
 
   const [currentIds, ignoreIds] = await Promise.all([
@@ -61,7 +71,10 @@ export async function refreshJobsForCompany(
       if (size) item.companySize = size;
     });
 
-    jobInfoQueue.add(add.map((job) => [key, job]));
+    jobInfoQueue.add(
+      add.map((job) => [key, job]),
+      setETagCallback(etagId, key, etag),
+    );
   }
 }
 
@@ -165,4 +178,26 @@ async function refreshJobInfo([companyKey, job]: [CompanyKey, Context<Job>]) {
   }
 
   await db.job.upsert(job.item);
+}
+
+async function getETag(
+  id: string,
+  key: CompanyKey,
+): Promise<string | undefined> {
+  if (!ats.supportsETag(key)) return undefined;
+  return db.eTag.get(id, key);
+}
+
+function setETagCallback(
+  id: string,
+  key: CompanyKey,
+  etag?: string,
+): OnGroupEnd | undefined {
+  if (!ats.supportsETag(key) || !etag) return undefined;
+  return async (hasFailure: boolean) => {
+    if (!hasFailure) {
+      // Set etag only when and if all job tasks have finished successfully
+      await db.eTag.set(id, key, etag);
+    }
+  };
 }

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -30,7 +30,7 @@ export async function refreshJobsForCompany(
 
   // If the company is not in the quick ref map, then it has 0 jobs on the board
   const exists = (await getCompanyQuickRef(companyId)) != null;
-  const etagId = `RefreshJobsForCompany_${exists}`;
+  const etagId = `RefreshJobsForCompany_${exists ? "exists" : "absent"}`;
 
   // Get the saved etag, unless we are doing forced reprocessing
   const etag =

--- a/packages/backend/src/sync/jobs.ts
+++ b/packages/backend/src/sync/jobs.ts
@@ -146,7 +146,7 @@ async function groupAtsJobs(
   // - We don't already have full job data
   // Better to do one big API call with unnecessary data than many small API calls
   if (
-    newJobs.length &&
+    newJobs.length > 1 &&
     newJobs.length > 0.1 * atsJobs.length &&
     !atsJobs[0]?.context
   ) {

--- a/packages/backend/src/utils/asyncQueue.ts
+++ b/packages/backend/src/utils/asyncQueue.ts
@@ -157,7 +157,7 @@ export class AsyncQueue<T> {
     try {
       void withAsyncContext(this.#name, async () => {
         await onGroupEnd(hasFailures);
-      });
+      }).catch(logError);
     } catch (error) {
       logError(error);
     }

--- a/packages/backend/src/utils/asyncQueue.ts
+++ b/packages/backend/src/utils/asyncQueue.ts
@@ -5,13 +5,13 @@ import {
   withAsyncContext,
 } from "../telemetry/telemetry.ts";
 
-interface Options {
+export interface Options {
   onComplete?: () => void;
   concurrentLimit?: number;
   taskDelayMs?: number;
 }
 
-type OnGroupEnd = (hasFailures: boolean) => Promise<void>;
+export type OnGroupEnd = (hasFailures: boolean) => Promise<void>;
 
 interface TaskGroup {
   remaining: number;

--- a/packages/backend/src/utils/asyncQueue.ts
+++ b/packages/backend/src/utils/asyncQueue.ts
@@ -155,7 +155,7 @@ export class AsyncQueue<T> {
 
   #endGroup(onGroupEnd: OnGroupEnd, hasFailures: boolean = false): void {
     try {
-      void withAsyncContext(this.#name, async () => {
+      void withAsyncContext(`${this.#name}_EndGroup`, async () => {
         await onGroupEnd(hasFailures);
       }).catch(logError);
     } catch (error) {

--- a/packages/backend/test/ats/ashby.test.ts
+++ b/packages/backend/test/ats/ashby.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { suite, test } from "node:test";
+import { Ashby } from "../../src/ats/ashby.ts";
+import type { CompanyResult } from "../../src/ats/ashby/companyResult.ts";
+import type { JobResult } from "../../src/ats/ashby/jobResult.ts";
+import { AppError } from "../../src/utils/AppError.ts";
+import { mockFetch } from "../setup.ts";
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function getFetchCall(fetchMock: ReturnType<typeof mockFetch>, index = 0) {
+  const call = fetchMock.mock.calls[index];
+  assert.ok(call);
+  const [url, init] = call.arguments as [string, RequestInit];
+  return { url, init };
+}
+
+function makeJob(overrides: Partial<JobResult> = {}): JobResult {
+  return {
+    id: "job-1",
+    title: "SOFTWARE ENGINEER",
+    department: "Engineering",
+    team: "Platform",
+    employmentType: "FullTime",
+    location: "Remote",
+    secondaryLocations: ["Seattle"],
+    publishedAt: "2026-01-02T03:04:05.000Z",
+    isListed: true,
+    isRemote: true,
+    workplaceType: "Remote",
+    address: {
+      postalAddress: {
+        addressRegion: "WA",
+        addressCountry: "US",
+        addressLocality: "Seattle",
+      },
+    },
+    jobUrl: "https://jobs.example.com/job-1",
+    applyUrl: "https://jobs.example.com/job-1/apply",
+    descriptionHtml: "<p>Build</p>",
+    descriptionPlain: "Build",
+    compensation: {
+      compensationTierSummary: "$100k-$120k",
+      scrapeableCompensationSalarySummary: "$100k-$120k",
+      compensationTiers: [],
+      summaryComponents: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeCompanyResult(jobs: JobResult[] = [makeJob()]): CompanyResult {
+  return { apiVersion: "1", jobs };
+}
+
+suite("Ashby", () => {
+  test("getCompany validates the board and formats the company", async () => {
+    const fetchMock = mockFetch(async () => jsonResponse(makeCompanyResult()));
+
+    assert.deepEqual(
+      await new Ashby().getCompany({ id: "acme", ats: "ashby" }),
+      {
+        id: "acme",
+        ats: "ashby",
+        name: "Acme",
+      },
+    );
+
+    const { url, init } = getFetchCall(fetchMock);
+    assert.equal(url, "https://api.ashbyhq.com/posting-api/job-board/acme/");
+    assert.ok(init.signal instanceof AbortSignal);
+  });
+
+  test("getJobs fetches the compensation-inclusive board route", async () => {
+    const fetchMock = mockFetch(async () => jsonResponse(makeCompanyResult()));
+
+    const jobs = await new Ashby().getJobs({ id: "acme", ats: "ashby" });
+
+    assert.equal(jobs.length, 1);
+    assert.equal(jobs[0]?.item.id, "job-1");
+    assert.equal(jobs[0]?.item.title, "Software Engineer");
+    assert.deepEqual(
+      jobs[0]?.context?.[0]?.content["compensation"],
+      makeJob().compensation,
+    );
+
+    const { url } = getFetchCall(fetchMock);
+    assert.equal(
+      url,
+      "https://api.ashbyhq.com/posting-api/job-board/acme/?includeCompensation=true",
+    );
+  });
+
+  test("getJobsETag returns unstable formatted data because Ashby has no ETag support", async () => {
+    const fetchMock = mockFetch(async () => jsonResponse(makeCompanyResult()));
+
+    const result = await new Ashby().getJobsETag(
+      { id: "acme", ats: "ashby" },
+      "etag-value",
+    );
+
+    assert.equal(result.stable, false);
+    assert.equal(result.data[0]?.item.id, "job-1");
+    assert.equal(result.etag, undefined);
+
+    const { init } = getFetchCall(fetchMock);
+    assert.equal(init.headers, undefined);
+    assert.equal(init.cache, undefined);
+  });
+
+  test("getSpecificJob finds the requested job and reports 404 when missing", async () => {
+    const ats = new Ashby();
+
+    mockFetch(async () =>
+      jsonResponse(makeCompanyResult([makeJob(), makeJob({ id: "job-2" })])),
+    );
+
+    const job = await ats.getSpecificJob({ id: "job-2", companyId: "acme" });
+    assert.equal(job.item.id, "job-2");
+
+    mockFetch(async () => jsonResponse(makeCompanyResult([makeJob()])));
+
+    await assert.rejects(
+      () => ats.getSpecificJob({ id: "missing", companyId: "acme" }),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.statusCode === 404 &&
+        error.message === "Job not found",
+    );
+  });
+});

--- a/packages/backend/test/ats/greenhouse.test.ts
+++ b/packages/backend/test/ats/greenhouse.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { suite, test } from "node:test";
+import { Greenhouse } from "../../src/ats/greenhouse.ts";
+import type {
+  CompanyResult,
+  JobResult,
+  JobResultBasic,
+} from "../../src/ats/greenhouseFormat.ts";
+import { mockFetch } from "../setup.ts";
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function getFetchCall(fetchMock: ReturnType<typeof mockFetch>, index = 0) {
+  const call = fetchMock.mock.calls[index];
+  assert.ok(call);
+  const [url, init] = call.arguments as [string, RequestInit];
+  return { url, init };
+}
+
+function makeJobBasic(overrides: Partial<JobResultBasic> = {}): JobResultBasic {
+  return {
+    id: 42,
+    internal_job_id: 7,
+    title: "SOFTWARE ENGINEER",
+    updated_at: "2026-02-03T04:05:06.000Z",
+    requisition_id: "REQ-42",
+    location: { name: "Seattle, WA" },
+    absolute_url: "https://boards.example.com/jobs/42",
+    metadata: { level: "senior" },
+    ...overrides,
+  };
+}
+
+function makeJob(overrides: Partial<JobResult> = {}): JobResult {
+  return {
+    ...makeJobBasic(),
+    content: "<p>Build</p>",
+    departments: [
+      { id: 1, name: "Engineering", child_ids: [], parent_id: undefined },
+    ],
+    offices: [
+      {
+        id: 2,
+        name: "Seattle",
+        location: "Seattle, WA",
+        child_ids: [],
+        parent_id: undefined,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+suite("Greenhouse", () => {
+  test("getCompany fetches and formats a Greenhouse board", async () => {
+    const result: CompanyResult = {
+      name: " Acme Inc. ",
+      content: "<p>About Acme</p>",
+    };
+    const fetchMock = mockFetch(async () => jsonResponse(result));
+
+    assert.deepEqual(
+      await new Greenhouse().getCompany({ id: "acme", ats: "greenhouse" }),
+      {
+        id: "acme",
+        ats: "greenhouse",
+        name: "Acme Inc.",
+        description: "<p>About Acme</p>",
+      },
+    );
+
+    const { url, init } = getFetchCall(fetchMock);
+    assert.equal(url, "https://boards-api.greenhouse.io/v1/boards/acme/");
+    assert.ok(init.signal instanceof AbortSignal);
+  });
+
+  [
+    {
+      name: "full jobs by default",
+      onlyMetadata: undefined,
+      body: { jobs: [makeJob()], meta: { total: 1 } },
+      expectedUrl:
+        "https://boards-api.greenhouse.io/v1/boards/acme//jobs?content=true",
+      expectedDescription: "<p>Build</p>",
+      expectedContext: true,
+    },
+    {
+      name: "metadata jobs when requested",
+      onlyMetadata: true,
+      body: { jobs: [makeJobBasic()], meta: { total: 1 } },
+      expectedUrl: "https://boards-api.greenhouse.io/v1/boards/acme//jobs",
+      expectedDescription: "",
+      expectedContext: false,
+    },
+  ].forEach(
+    ({
+      name,
+      onlyMetadata,
+      body,
+      expectedUrl,
+      expectedDescription,
+      expectedContext,
+    }) => {
+      test(`getJobs fetches ${name}`, async () => {
+        const fetchMock = mockFetch(async () => jsonResponse(body));
+
+        const jobs = await new Greenhouse().getJobs(
+          { id: "acme", ats: "greenhouse" },
+          onlyMetadata,
+        );
+
+        assert.equal(jobs[0]?.item.id, "42");
+        assert.equal(jobs[0]?.item.title, "Software Engineer");
+        assert.equal(jobs[0]?.item.description, expectedDescription);
+        assert.equal(!!jobs[0]?.context, expectedContext);
+
+        const { url } = getFetchCall(fetchMock);
+        assert.equal(url, expectedUrl);
+      });
+    },
+  );
+
+  test("getJobsETag sends If-None-Match and returns stable on 304", async () => {
+    const fetchMock = mockFetch(
+      async () =>
+        new Response(null, { status: 304, statusText: "Not Modified" }),
+    );
+
+    assert.deepEqual(
+      await new Greenhouse().getJobsETag(
+        { id: "acme", ats: "greenhouse" },
+        "etag-value",
+      ),
+      { stable: true },
+    );
+
+    const { url, init } = getFetchCall(fetchMock);
+    assert.equal(
+      url,
+      "https://boards-api.greenhouse.io/v1/boards/acme//jobs?content=true",
+    );
+    assert.equal(init.cache, "force-cache");
+    assert.deepEqual(init.headers, { "If-None-Match": "etag-value" });
+  });
+
+  test("getExampleJob fetches metadata first, then the full selected job", async () => {
+    const fetchMock = mockFetch(async (url) => {
+      if (String(url).endsWith("//jobs")) {
+        return jsonResponse({
+          jobs: [makeJobBasic()],
+          meta: { total: 1 },
+        });
+      }
+
+      return jsonResponse(makeJob());
+    });
+
+    const job = await new Greenhouse().getExampleJob({
+      id: "acme",
+      ats: "greenhouse",
+    });
+
+    assert.equal(job?.item.id, "42");
+    assert.equal(job?.item.description, "<p>Build</p>");
+    assert.equal(fetchMock.mock.callCount(), 2);
+    assert.equal(
+      getFetchCall(fetchMock, 1).url,
+      "https://boards-api.greenhouse.io/v1/boards/acme/jobs/42",
+    );
+  });
+});

--- a/packages/backend/test/ats/greenhouse.test.ts
+++ b/packages/backend/test/ats/greenhouse.test.ts
@@ -83,7 +83,7 @@ suite("Greenhouse", () => {
   [
     {
       name: "full jobs by default",
-      onlyMetadata: undefined,
+      meta: undefined,
       body: { jobs: [makeJob()], meta: { total: 1 } },
       expectedUrl:
         "https://boards-api.greenhouse.io/v1/boards/acme//jobs?content=true",
@@ -92,7 +92,7 @@ suite("Greenhouse", () => {
     },
     {
       name: "metadata jobs when requested",
-      onlyMetadata: true,
+      meta: true,
       body: { jobs: [makeJobBasic()], meta: { total: 1 } },
       expectedUrl: "https://boards-api.greenhouse.io/v1/boards/acme//jobs",
       expectedDescription: "",
@@ -101,7 +101,7 @@ suite("Greenhouse", () => {
   ].forEach(
     ({
       name,
-      onlyMetadata,
+      meta,
       body,
       expectedUrl,
       expectedDescription,
@@ -112,7 +112,7 @@ suite("Greenhouse", () => {
 
         const jobs = await new Greenhouse().getJobs(
           { id: "acme", ats: "greenhouse" },
-          onlyMetadata,
+          meta,
         );
 
         assert.equal(jobs[0]?.item.id, "42");

--- a/packages/backend/test/ats/lever.test.ts
+++ b/packages/backend/test/ats/lever.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { suite, test } from "node:test";
+import { Lever } from "../../src/ats/lever.ts";
+import type { JobResult } from "../../src/ats/leverFormat.ts";
+import { AppError } from "../../src/utils/AppError.ts";
+import { mockFetch } from "../setup.ts";
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function getFetchCall(fetchMock: ReturnType<typeof mockFetch>, index = 0) {
+  const call = fetchMock.mock.calls[index];
+  assert.ok(call);
+  const [url, init] = call.arguments as [string, RequestInit];
+  return { url, init };
+}
+
+function makeJob(overrides: Partial<JobResult> = {}): JobResult {
+  return {
+    id: "job-1",
+    createdAt: Date.parse("2026-03-04T05:06:07.000Z"),
+    applyUrl: "https://jobs.example.com/job-1/apply",
+    text: "SOFTWARE ENGINEER",
+    description: "Opening",
+    additional: "<p>More</p>",
+    salaryDescription: "<p>$100k</p>",
+    lists: [{ text: "Responsibilities", content: "<li>Build</li>" }],
+    categories: {
+      commitment: "Full-time",
+      location: "Remote",
+      team: "Platform",
+      department: "Engineering",
+      allLocations: ["Seattle", "Remote"],
+    },
+    country: "US",
+    workplaceType: "remote",
+    salaryRange: {
+      currency: "USD",
+      interval: "year",
+      min: 100_000,
+      max: 120_000,
+    },
+    ...overrides,
+  };
+}
+
+suite("Lever", () => {
+  test("getCompany validates the board and formats the company", async () => {
+    const fetchMock = mockFetch(async () => jsonResponse([makeJob()]));
+
+    assert.deepEqual(
+      await new Lever().getCompany({ id: "acme", ats: "lever" }),
+      {
+        id: "acme",
+        ats: "lever",
+        name: "Acme",
+      },
+    );
+
+    const { url, init } = getFetchCall(fetchMock);
+    assert.equal(
+      url,
+      "https://api.lever.co/v0/postings/acme/?mode=json&limit=1",
+    );
+    assert.ok(init.signal instanceof AbortSignal);
+  });
+
+  test("getJobs fetches and formats the public postings route", async () => {
+    const fetchMock = mockFetch(async () => jsonResponse([makeJob()]));
+
+    const jobs = await new Lever().getJobs({ id: "acme", ats: "lever" });
+
+    assert.equal(jobs[0]?.item.id, "job-1");
+    assert.equal(jobs[0]?.item.title, "Software Engineer");
+    assert.equal(jobs[0]?.item.description.includes("Responsibilities"), true);
+
+    const { url } = getFetchCall(fetchMock);
+    assert.equal(url, "https://api.lever.co/v0/postings/acme/?mode=json");
+  });
+
+  test("getJobsETag sends If-None-Match and returns stable on 304", async () => {
+    const fetchMock = mockFetch(
+      async () =>
+        new Response(null, { status: 304, statusText: "Not Modified" }),
+    );
+
+    assert.deepEqual(
+      await new Lever().getJobsETag({ id: "acme", ats: "lever" }, "etag-value"),
+      { stable: true },
+    );
+
+    const { init } = getFetchCall(fetchMock);
+    assert.equal(init.cache, "force-cache");
+    assert.deepEqual(init.headers, { "If-None-Match": "etag-value" });
+  });
+
+  test("getExampleJob formats the first returned posting and handles empty boards", async () => {
+    const lever = new Lever();
+
+    mockFetch(async () => jsonResponse([makeJob()]));
+    assert.equal(
+      (await lever.getExampleJob({ id: "acme", ats: "lever" }))?.item.id,
+      "job-1",
+    );
+
+    mockFetch(async () => jsonResponse([]));
+    assert.equal(
+      await lever.getExampleJob({ id: "acme", ats: "lever" }),
+      undefined,
+    );
+  });
+
+  test("getSpecificJob finds the requested posting and reports 404 when missing", async () => {
+    const lever = new Lever();
+
+    mockFetch(async () => jsonResponse([makeJob(), makeJob({ id: "job-2" })]));
+
+    const job = await lever.getSpecificJob({ id: "job-2", companyId: "acme" });
+    assert.equal(job.item.id, "job-2");
+
+    mockFetch(async () => jsonResponse([makeJob()]));
+
+    await assert.rejects(
+      () => lever.getSpecificJob({ id: "missing", companyId: "acme" }),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.statusCode === 404 &&
+        error.message === "Job not found",
+    );
+  });
+});

--- a/packages/backend/test/db/ETagContainer.test.ts
+++ b/packages/backend/test/db/ETagContainer.test.ts
@@ -1,0 +1,69 @@
+import { connectDB, Container } from "dry-utils-cosmosdb";
+import assert from "node:assert/strict";
+import { before, suite, test } from "node:test";
+import { ETagContainer } from "../../src/db/ETagContainer.ts";
+import type { ETag } from "../../src/models/models.ts";
+
+suite("ETagContainer", () => {
+  let etag: ETagContainer;
+
+  before(async () => {
+    const containers = await connectDB({
+      endpoint: "unused-for-mock",
+      key: "unused-for-mock",
+      name: "unused-for-mock",
+      containers: [ETagContainer.ContainerOptions()],
+      mockDBData: { etag: [] },
+    });
+
+    etag = new ETagContainer(containers["etag"]! as Container<ETag>);
+  });
+
+  test("defines its container options", () => {
+    assert.deepEqual(ETagContainer.ContainerOptions(), {
+      name: "etag",
+      partitionKey: "atsCompany",
+      indexExclusions: "all",
+      ttlSeconds: 2592000,
+    });
+  });
+
+  test("returns undefined when a resource has no saved ETag", async () => {
+    const result = await etag.get("/jobs", {
+      id: "missing",
+      ats: "greenhouse",
+    });
+
+    assert.equal(result, undefined);
+  });
+
+  test("saves independent ETags for a company's resource URLs", async () => {
+    const key = { id: "acme", ats: "lever" } as const;
+    const otherKey = { id: "other", ats: "lever" } as const;
+
+    await etag.set("Path_1", key, 'W/"basic"');
+    await etag.set("Path_2", key, 'W/"single"');
+    await etag.set("Path_1", otherKey, 'W/"other"');
+
+    assert.equal(await etag.get("Path_1", key), 'W/"basic"');
+    assert.equal(await etag.get("Path_2", key), 'W/"single"');
+    assert.equal(await etag.get("Path_1", otherKey), 'W/"other"');
+  });
+
+  test("normalizes relative URLs for Cosmos DB IDs", async () => {
+    const key = { id: "acme", ats: "greenhouse" } as const;
+
+    await etag.set("/url?content=true#open", key, 'W/"full"');
+
+    const saved = await etag.getItem(
+      "_url_content=true_open",
+      "greenhouse+acme",
+    );
+    assert.deepEqual(saved, {
+      id: "_url_content=true_open",
+      atsCompany: "greenhouse+acme",
+      etag: 'W/"full"',
+    });
+    assert.equal(await etag.get("/url?content=true#open", key), 'W/"full"');
+  });
+});

--- a/packages/backend/test/db/JobContainer.test.ts
+++ b/packages/backend/test/db/JobContainer.test.ts
@@ -82,6 +82,15 @@ suite("JobContainer", () => {
     assert.deepEqual(await jobs.getCompanyIds(), ["acme", "beta"]);
   });
 
+  test("reads expired job IDs from a single company partition", async () => {
+    const cutoff = now - 90 * MS_PER_DAY;
+
+    await jobs.upsert(job("old-acme", "acme", cutoff - 1));
+    await jobs.upsert(job("old-beta", "beta", cutoff - 1));
+
+    assert.deepEqual(await jobs.getExpiredIds("acme", cutoff), ["old-acme"]);
+  });
+
   test("saves and removes jobs", async () => {
     const saved = job("new", "new-company", now);
 

--- a/packages/backend/test/setup.ts
+++ b/packages/backend/test/setup.ts
@@ -1,6 +1,6 @@
 import { configureGlobal } from "dry-utils-logger";
 import express from "express";
-import { beforeEach, mock } from "node:test";
+import { afterEach, beforeEach, mock } from "node:test";
 import { configureTelemetry } from "../src/telemetry/telemetry.ts";
 import { Bag } from "../src/types/types.ts";
 
@@ -24,6 +24,18 @@ beforeEach(() => {
 
 // #endregion
 
+// #region Fetch
+
+const originalFetch = globalThis.fetch;
+
+export function mockFetch(impl: typeof globalThis.fetch) {
+  const fn = mock.fn(impl);
+  globalThis.fetch = fn;
+  return fn;
+}
+
+// #endregion
+
 const database = await import("../src/db/db.ts");
 mock.method(database.db, "connect", async () => {});
 
@@ -32,3 +44,7 @@ mock.method(express.application, "listen", () => ({
     // no-op server stub
   },
 }));
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});

--- a/packages/backend/test/sync/jobs.test.ts
+++ b/packages/backend/test/sync/jobs.test.ts
@@ -49,7 +49,7 @@ suite("refreshJobsForCompany", () => {
 
     assert.equal(eTagSet.mock.callCount(), 1);
     assert.deepEqual(eTagSet.mock.calls[0]?.arguments, [
-      "RefreshJobsForCompany_true",
+      "RefreshJobsForCompany_exists",
       key,
       "new-etag",
     ]);

--- a/packages/backend/test/sync/jobs.test.ts
+++ b/packages/backend/test/sync/jobs.test.ts
@@ -8,6 +8,53 @@ import { JOB_EXPIRY_MS } from "../../src/utils/constants.ts";
 const key = { id: "acme", ats: "lever" } as const;
 
 suite("refreshJobsForCompany", () => {
+  test("saves a new ETag when an unstable ATS response has no new jobs", async (context) => {
+    const eTagSet = context.mock.fn(async () => {});
+
+    context.mock.getter(db, "metadata", () => ({
+      getItem: async () => ({
+        id: "company",
+        companyQuickRef: [[key.id, "Acme"]],
+      }),
+    }));
+    context.mock.getter(db, "eTag", () => ({
+      get: async () => "old-etag",
+      set: eTagSet,
+    }));
+    context.mock.getter(db, "ignoreJob", () => ({
+      getIds: async () => [],
+    }));
+    context.mock.getter(db, "job", () => ({
+      getIds: async () => ["job-1"],
+    }));
+    context.mock.method(ats, "supportsETag", () => true);
+    context.mock.method(ats, "getJobsETag", async () => ({
+      stable: false,
+      etag: "new-etag",
+      data: [
+        {
+          item: {
+            id: "job-1",
+            companyId: key.id,
+            title: "Software Engineer",
+            description: "",
+            postTS: Date.now(),
+            applyUrl: "https://example.com/job-1",
+          },
+        },
+      ],
+    }));
+
+    await refreshJobsForCompany(key);
+
+    assert.equal(eTagSet.mock.callCount(), 1);
+    assert.deepEqual(eTagSet.mock.calls[0]?.arguments, [
+      "RefreshJobsForCompany_true",
+      key,
+      "new-etag",
+    ]);
+  });
+
   test("removes expired saved jobs when the ATS ETag is stable", async (context) => {
     const now = Date.now();
     const getExpiredIds = context.mock.fn(async () => ["expired"]);

--- a/packages/backend/test/sync/jobs.test.ts
+++ b/packages/backend/test/sync/jobs.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { suite, test } from "node:test";
+import { ats } from "../../src/ats/ats.ts";
+import { db } from "../../src/db/db.ts";
+import { refreshJobsForCompany } from "../../src/sync/jobs.ts";
+import { JOB_EXPIRY_MS } from "../../src/utils/constants.ts";
+
+const key = { id: "acme", ats: "lever" } as const;
+
+suite("refreshJobsForCompany", () => {
+  test("removes expired saved jobs when the ATS ETag is stable", async (context) => {
+    const now = Date.now();
+    const getExpiredIds = context.mock.fn(async () => ["expired"]);
+    const removeMany = context.mock.fn(async () => []);
+
+    context.mock.getter(db, "metadata", () => ({
+      getItem: async () => ({
+        id: "company",
+        companyQuickRef: [[key.id, "Acme"]],
+      }),
+    }));
+    context.mock.getter(db, "eTag", () => ({
+      get: async () => "etag-value",
+    }));
+    context.mock.getter(db, "job", () => ({
+      getExpiredIds,
+      removeMany,
+    }));
+    context.mock.method(ats, "supportsETag", () => true);
+    context.mock.method(ats, "getJobsETag", async () => ({ stable: true }));
+
+    await refreshJobsForCompany(key);
+
+    assert.equal(getExpiredIds.mock.callCount(), 1);
+    const [companyId, cutoff] = getExpiredIds.mock.calls[0]?.arguments ?? [];
+    assert.equal(companyId, key.id);
+    assert.equal(typeof cutoff, "number");
+    assert.ok(cutoff >= now - JOB_EXPIRY_MS);
+    assert.ok(cutoff <= Date.now() - JOB_EXPIRY_MS);
+    assert.equal(removeMany.mock.callCount(), 1);
+    assert.deepEqual(removeMany.mock.calls[0]?.arguments, [
+      ["expired"],
+      key.id,
+    ]);
+  });
+});

--- a/packages/cli/src/e2e/flows.ts
+++ b/packages/cli/src/e2e/flows.ts
@@ -205,6 +205,31 @@ const jobs: Step[] = [
   ),
 ];
 
+const manualAts = "ashby";
+const manualCompanyId = "asdf";
+const manual: Step[] = [
+  /*formStep(
+    `Add ${manualAts} company ${manualCompanyId}`,
+    req.put("company", {
+      asAdmin: false,
+      body: { ats: manualAts, id: manualCompanyId },
+    }),
+    res.ok(),
+  ),*/
+  formStep(
+    `Specific Company ${manualCompanyId}`,
+    req.post("refresh/jobs", {
+      body: { ats: manualAts, companyIds: [manualCompanyId] },
+    }),
+    res.accepted,
+  ),
+  /*formStep(
+    `Delete ${manualAts} company ${manualCompanyId}`,
+    req.del("company", { body: { ats: manualAts, id: manualCompanyId } }),
+    res.ok(),
+  ),*/
+];
+
 /*
 To be added to a flow:
 /refresh/jobs for specific ATS
@@ -232,4 +257,5 @@ export const flows: Record<string, Step[]> = {
   companies,
   jobs,
   smoke: [...pings, ...allErrors, ...unknowns, ...companies, ...jobs],
+  manual,
 };


### PR DESCRIPTION
For ATS that support it, during job refresh we should
- Save the returned ETags into the DB
- Use the stored ETags when making requests
- Handle Not Modified responses correctly
- Handle reprocessing overrides correctly