### PR TITLE
Remove unused jobs refresh filter

### DIFF
--- a/packages/backend/src/controllers/job.ts
+++ b/packages/backend/src/controllers/job.ts
@@ -94,7 +94,6 @@ async function readJobsByFilters({
   payCadence,
   currency,
   orderBy,
-  refresh,
 }: Filters) {
   // The limit of 24 items is intentional to prevent excessive data retrieval.
   const query = new Query().top(24);
@@ -149,11 +148,6 @@ async function readJobsByFilters({
 
   if (minSalary) {
     query.whereCondition("salaryRange.min", ">=", minSalary);
-  }
-
-  if (refresh) {
-    const cutoffSeconds = Math.floor((Date.now() - MS_PER_DAY) / 1000);
-    query.whereCondition("_ts", ">=", cutoffSeconds);
   }
 
   // Substring Matches

--- a/packages/backend/src/middleware/inputValidators.ts
+++ b/packages/backend/src/middleware/inputValidators.ts
@@ -78,7 +78,6 @@ const FiltersSchema = z.object({
   maxExperience: coerceInt(z.int().nonnegative().max(100)),
   minSalary: coerceInt(z.int().positive().max(10_000_000)),
   orderBy: soft(lower(JobOrderBy)),
-  refresh: coerceString(z.stringbool()),
 });
 
 const beaconSchema = z.object({

--- a/packages/backend/src/models/clientModels.ts
+++ b/packages/backend/src/models/clientModels.ts
@@ -31,8 +31,6 @@ export interface Filters {
   minSalary?: number;
   // Ordering
   orderBy?: JobOrderBy;
-  // Admin
-  refresh?: boolean;
 }
 
 export interface RefreshJobsOptions {

--- a/packages/backend/test/middleware/inputValidators.test.ts
+++ b/packages/backend/test/middleware/inputValidators.test.ts
@@ -250,12 +250,6 @@ suite("useFilters", () => {
     { isRemote: "FALSE" },
     { isRemote: 0 },
     { isRemote: 1 },
-    { refresh: "true" },
-    { refresh: "TRUE" },
-    { refresh: "false" },
-    { refresh: "FALSE" },
-    { refresh: 0 },
-    { refresh: 1 },
     { workTimeBasis: "full_time" },
     { workTimeBasis: "part_time" },
     { workTimeBasis: "variable" },
@@ -333,7 +327,6 @@ suite("useFilters", () => {
       const expected = {
         ...input,
         ...coerceBool("isRemote", input.isRemote),
-        ...coerceBool("refresh", input.refresh),
         ...coerceInt("daysSince", input.daysSince),
         ...coerceInt("maxExperience", input.maxExperience),
         ...coerceInt("minSalary", input.minSalary),
@@ -383,7 +376,6 @@ suite("useFilters", () => {
     { orderBy: "salaryRange.min" },
     { orderBy: "invalid_value" },
     { orderBy: 123 },
-    { refresh: "not-a-bool" },
   ];
 
   invalidCases.forEach((input) => {

--- a/packages/frontend/src/api/apiTypes.ts
+++ b/packages/frontend/src/api/apiTypes.ts
@@ -67,6 +67,4 @@ export interface FilterModelApi {
   minSalary?: number;
   // Ordering
   orderBy?: JobOrderBy;
-  // Admin
-  refresh?: boolean;
 }

--- a/packages/frontend/src/api/filterModel.ts
+++ b/packages/frontend/src/api/filterModel.ts
@@ -202,7 +202,6 @@ export class FilterModel {
     this.#filters.jobId = !isEmpty(this.#filters.companyId)
       ? normIdString(get("jobId"))
       : undefined;
-    this.#filters.refresh = normBoolean(get("refresh"));
   }
 }
 

--- a/packages/frontend/src/jobs/filters/filters.css
+++ b/packages/frontend/src/jobs/filters/filters.css
@@ -44,8 +44,7 @@
   padding-block-end: var(--space-6);
 
   /* Hidden fields */
-  & [name="jobId"],
-  & [name="refresh"] {
+  & [name="jobId"] {
     display: none;
   }
 }

--- a/packages/frontend/src/jobs/filters/filters.ts
+++ b/packages/frontend/src/jobs/filters/filters.ts
@@ -149,12 +149,6 @@ const filterDefs: Record<string, FormElementDef[]> = {
       name: "jobId",
       label: "Job ID",
     },
-    {
-      // Hidden via CSS
-      type: "jb-form-input",
-      name: "refresh",
-      label: "Refresh",
-    },
   ],
   Results: [
     {


### PR DESCRIPTION
### Motivation
- The `refresh=true` admin querystring for `/jobs` was added earlier but is unused and adds dead surface area in both frontend and backend filter handling.

### Description
- Removed the `refresh` filter from backend request validation (`FiltersSchema`) and the `Filters` input type so it is no longer accepted or typed. 
- Dropped the `refresh` branch from the job query builder in `readJobsByFilters` so DB queries no longer filter by `_ts` for this flag. 
- Removed `refresh` from the frontend `FilterModel` parsing and `FilterModelApi` types so querystrings are no longer parsed into a refresh flag. 
- Removed the hidden `refresh` form input and adjusted the CSS to keep only `jobId` as a hidden field. 
- Updated backend input validator tests to stop asserting support for `refresh` values.

Files changed (high level): `packages/backend/src/controllers/job.ts`, `packages/backend/src/middleware/inputValidators.ts`, `packages/backend/src/models/clientModels.ts`, `packages/backend/test/middleware/inputValidators.test.ts`, `packages/frontend/src/api/apiTypes.ts`, `packages/frontend/src/api/filterModel.ts`, `packages/frontend/src/jobs/filters/filters.ts`, and `packages/frontend/src/jobs/filters/filters.css`.

### Testing
- Ran frontend focused tests with `npm run test --workspace=frontend -- filterModel filters` and the suite passed. 
- Ran backend focused tests with `npm run test --workspace=backend -- inputValidators` and the suite passed. 
- Ran the repository pre-checkin with `npm run pre-checkin` (lint/format/tests) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4548617ed88333981fbfe6f03724f5)