### PR TITLE
Remove currency filter and simplify remote location matching

### DIFF
--- a/packages/backend/src/controllers/job.ts
+++ b/packages/backend/src/controllers/job.ts
@@ -92,7 +92,6 @@ async function readJobsByFilters({
   jobFamily,
   companyStage,
   payCadence,
-  currency,
   orderBy,
 }: Filters) {
   // The limit of 24 items is intentional to prevent excessive data retrieval.
@@ -129,10 +128,6 @@ async function readJobsByFilters({
 
   if (payCadence) {
     query.whereCondition("salaryRange.cadence", "=", payCadence);
-  }
-
-  if (currency) {
-    query.whereCondition("salaryRange.currency", "=", currency.toUpperCase());
   }
 
   // Range Matches
@@ -201,26 +196,22 @@ export function buildLocationWhere({
 
   const noCity = `NOT IS_DEFINED(c.primaryLocation.city)`;
   const noRegion = `NOT IS_DEFINED(c.primaryLocation.regionCode)`;
-  const noCountry = `NOT IS_DEFINED(c.primaryLocation.countryCode)`;
-
-  const usCountry = `c.primaryLocation.countryCode = 'US'`;
   const stateMatch = `c.primaryLocation.regionCode = @state`;
   const cityMatch = `(CONTAINS(c.primaryLocation.city, @city, true) OR CONTAINS(@city, c.primaryLocation.city, true))`;
 
-  const usOrGlobal = `(${usCountry} OR ${noCountry})`;
-  const countryWideRemote = `${noCity} AND ${noRegion} AND ${usOrGlobal}`;
-  const stateWideRemote = `${noCity} AND ${stateMatch} AND ${usCountry}`;
+  const countryWideRemote = `${noCity} AND ${noRegion}`;
+  const stateWideRemote = `${noCity} AND ${stateMatch}`;
 
   let locClause: string;
   let remoteMatches = [countryWideRemote];
 
   if (city && state) {
-    locClause = `${usCountry} AND ${stateMatch} AND ${cityMatch}`;
+    locClause = `${stateMatch} AND ${cityMatch}`;
     remoteMatches = [stateWideRemote, countryWideRemote];
   } else if (state) {
-    locClause = `${usCountry} AND ${stateMatch}`;
+    locClause = stateMatch;
   } else {
-    locClause = `${usCountry} AND ${cityMatch}`;
+    locClause = cityMatch;
   }
 
   if (isRemote !== false) {

--- a/packages/backend/src/middleware/inputValidators.ts
+++ b/packages/backend/src/middleware/inputValidators.ts
@@ -64,13 +64,6 @@ const FiltersSchema = z.object({
   jobFamily: soft(lower(JobFamily)),
   companyStage: soft(lower(CompanyStage)),
   payCadence: soft(lower(PayCadence)),
-  currency: soft(
-    z
-      .string()
-      .length(3)
-      .regex(/^[a-z]+$/i)
-      .toUpperCase(),
-  ),
   title: soft(SearchSchema),
   city: soft(SearchSchema),
   state: soft(upper(UsState)),

--- a/packages/backend/src/models/clientModels.ts
+++ b/packages/backend/src/models/clientModels.ts
@@ -20,7 +20,6 @@ export interface Filters {
   jobFamily?: JobFamily;
   companyStage?: CompanyStage;
   payCadence?: PayCadence;
-  currency?: string;
   // Substring Match
   title?: string;
   city?: string;

--- a/packages/backend/src/models/extractionModels.ts
+++ b/packages/backend/src/models/extractionModels.ts
@@ -296,7 +296,6 @@ export const ExtractionFilters = z
     jobFamily: JobFamily,
     companyStage: CompanyStage,
     payCadence: PayCadence,
-    currency: zString("ISO 4217 currency code (uppercase), e.g. 'USD'."),
     title: zString(
       "A partial match search on job title text.",
       "Example: 'port' will match 'Support Engineer' and 'Portfolio Manager'.",
@@ -323,9 +322,12 @@ export const ExtractionFilters = z
       "Example: 'Roles that require less than 5 years experience' → 4.",
     ),
     minSalary: zPosNum(
-      "Minimum salary the user is looking for, in the specified currency and cadence.",
+      "Minimum USD salary the user is looking for, in the specified cadence.",
+      "Only set this for USD or dollar-denominated salary preferences.",
+      "For other currencies, leave this unset and describe the currency preference in unmappedIntent.",
       "Example: '$100k a year' → 100000.",
       "Example: '$50 an hour' → 50.",
+      "Example: 'EUR jobs over 100k' → -1 and unmappedIntent notes the EUR preference.",
     ),
     unmappedIntent: zString(
       "Minimally describe missing filters the user wished existed.",
@@ -340,6 +342,7 @@ export const ExtractionFilters = z
       "Fix common misspellings and typos.",
       "Set string fields to '' when not explicitly stated.",
       "Set numeric fields to -1 when not explicitly stated.",
+      "Non-USD salary currency preferences are unsupported; put them in unmappedIntent instead of minSalary.",
     ].join(" "),
   );
 export type ExtractionFilters = z.infer<typeof ExtractionFilters>;

--- a/packages/backend/src/models/extractionModels.ts
+++ b/packages/backend/src/models/extractionModels.ts
@@ -322,12 +322,9 @@ export const ExtractionFilters = z
       "Example: 'Roles that require less than 5 years experience' → 4.",
     ),
     minSalary: zPosNum(
-      "Minimum USD salary the user is looking for, in the specified cadence.",
-      "Only set this for USD or dollar-denominated salary preferences.",
-      "For other currencies, leave this unset and describe the currency preference in unmappedIntent.",
+      "Minimum salary the user is looking for, in the specified currency and cadence.",
       "Example: '$100k a year' → 100000.",
       "Example: '$50 an hour' → 50.",
-      "Example: 'EUR jobs over 100k' → -1 and unmappedIntent notes the EUR preference.",
     ),
     unmappedIntent: zString(
       "Minimally describe missing filters the user wished existed.",
@@ -342,7 +339,6 @@ export const ExtractionFilters = z
       "Fix common misspellings and typos.",
       "Set string fields to '' when not explicitly stated.",
       "Set numeric fields to -1 when not explicitly stated.",
-      "Non-USD salary currency preferences are unsupported; put them in unmappedIntent instead of minSalary.",
     ].join(" "),
   );
 export type ExtractionFilters = z.infer<typeof ExtractionFilters>;

--- a/packages/backend/test/controllers/job.test.ts
+++ b/packages/backend/test/controllers/job.test.ts
@@ -17,11 +17,9 @@ type LocationWhereCase = {
 
 const noCity = `NOT IS_DEFINED(c.primaryLocation.city)`;
 const noRegion = `NOT IS_DEFINED(c.primaryLocation.regionCode)`;
-const noCountry = `NOT IS_DEFINED(c.primaryLocation.countryCode)`;
-const usCountry = `c.primaryLocation.countryCode = 'US'`;
 const stateMatch = `c.primaryLocation.regionCode = @state`;
 const cityMatch = `(CONTAINS(c.primaryLocation.city, @city, true) OR CONTAINS(@city, c.primaryLocation.city, true))`;
-const countryWideRemote = `${noCity} AND ${noRegion} AND (${usCountry} OR ${noCountry})`;
+const countryWideRemote = `${noCity} AND ${noRegion}`;
 
 suite("buildLocationWhere", () => {
   test("returns undefined without city or state", () => {
@@ -34,25 +32,19 @@ suite("buildLocationWhere", () => {
         name: "city and state",
         filters: { city: "Seattle", state: "WA", isRemote: false },
         expected: [
-          `${usCountry} AND ${stateMatch} AND ${cityMatch}`,
+          `${stateMatch} AND ${cityMatch}`,
           { "@city": "Seattle", "@state": "WA" },
         ],
       },
       {
         name: "state only",
         filters: { state: "WA", isRemote: false },
-        expected: [
-          `${usCountry} AND ${stateMatch}`,
-          { "@city": "", "@state": "WA" },
-        ],
+        expected: [stateMatch, { "@city": "", "@state": "WA" }],
       },
       {
         name: "city only",
         filters: { city: "Seattle", isRemote: false },
-        expected: [
-          `${usCountry} AND ${cityMatch}`,
-          { "@city": "Seattle", "@state": "" },
-        ],
+        expected: [cityMatch, { "@city": "Seattle", "@state": "" }],
       },
     ];
 
@@ -64,26 +56,26 @@ suite("buildLocationWhere", () => {
   test("includes remote wildcard matches by default", () => {
     const cases: LocationWhereCase[] = [
       {
-        name: "city and state includes state-wide, US-wide, and worldwide remote",
+        name: "city and state includes state-wide and country-wide remote",
         filters: { city: "Seattle", state: "WA" },
         expected: [
-          `${usCountry} AND ${stateMatch} AND ${cityMatch} OR (c.presence = 'remote' AND (${noCity} AND ${stateMatch} AND ${usCountry} OR ${countryWideRemote}))`,
+          `${stateMatch} AND ${cityMatch} OR (c.presence = 'remote' AND (${noCity} AND ${stateMatch} OR ${countryWideRemote}))`,
           { "@city": "Seattle", "@state": "WA" },
         ],
       },
       {
-        name: "state only includes US-wide and worldwide remote",
+        name: "state only includes country-wide remote",
         filters: { state: "WA" },
         expected: [
-          `${usCountry} AND ${stateMatch} OR (c.presence = 'remote' AND (${countryWideRemote}))`,
+          `${stateMatch} OR (c.presence = 'remote' AND (${countryWideRemote}))`,
           { "@city": "", "@state": "WA" },
         ],
       },
       {
-        name: "city only includes US-wide and worldwide remote",
+        name: "city only includes country-wide remote",
         filters: { city: "Seattle" },
         expected: [
-          `${usCountry} AND ${cityMatch} OR (c.presence = 'remote' AND (${countryWideRemote}))`,
+          `${cityMatch} OR (c.presence = 'remote' AND (${countryWideRemote}))`,
           { "@city": "Seattle", "@state": "" },
         ],
       },

--- a/packages/backend/test/middleware/inputValidators.test.ts
+++ b/packages/backend/test/middleware/inputValidators.test.ts
@@ -265,8 +265,6 @@ suite("useFilters", () => {
     { payCadence: "hourly" },
     { payCadence: "HOURLY" },
     { payCadence: "" },
-    { currency: "USD" },
-    { currency: "usd" },
     { title: SEARCH_TERM },
     { city: SEARCH_TERM },
     { state: "WA" },
@@ -336,7 +334,6 @@ suite("useFilters", () => {
         ...lowercase("payCadence", input.payCadence),
         ...lowercase("orderBy", input.orderBy),
         ...uppercase("state", input.state),
-        ...(input.currency ? { currency: input.currency.toUpperCase() } : {}),
       };
       assert.deepEqual(result, expected);
     });
@@ -354,10 +351,6 @@ suite("useFilters", () => {
     { companyStage: 123 },
     { payCadence: "invalid_value" },
     { payCadence: 123 },
-    { currency: "" },
-    { currency: "US" },
-    { currency: "USDD" },
-    { currency: 123 },
     { title: SEARCH_TOO_SHORT },
     { title: SEARCH_TOO_LONG },
     { city: SEARCH_TOO_SHORT },

--- a/packages/backend/test/models/extractionModels.test.ts
+++ b/packages/backend/test/models/extractionModels.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { suite, test } from "node:test";
+
+import { ExtractionFilters } from "../../src/models/extractionModels.ts";
+
+suite("ExtractionFilters", () => {
+  test("does not include unsupported currency filter", () => {
+    const result = ExtractionFilters.safeParse({
+      isRemote: "",
+      workTimeBasis: "",
+      jobFamily: "",
+      companyStage: "",
+      payCadence: "",
+      currency: "EUR",
+      title: "",
+      city: "",
+      state: "",
+      daysSince: -1,
+      maxExperience: -1,
+      minSalary: -1,
+      unmappedIntent: "EUR salary preference is unsupported",
+    });
+
+    assert.equal(result.success, true);
+    if (!result.success) throw result.error;
+    assert.equal("currency" in result.data, false);
+  });
+});


### PR DESCRIPTION
### Motivation

- Remove the `currency` filter from the job search surface to simplify the API and avoid filtering jobs by salary currency at query time.
- Relax location remote-matching logic to no longer special-case a US country check so remote jobs can be matched more broadly.

### Description

- Removed `currency` from the `Filters` interface in `clientModels.ts` and from the `FiltersSchema` in `inputValidators.ts`, and removed related coercion/uppercasing logic and test cases.
- Removed the `salaryRange.currency` `WHERE` clause from `readJobsByFilters` so searches no longer filter by currency.
- Simplified `buildLocationWhere` by deleting `noCountry`/`usCountry` checks and changing remote wildcard clauses and `locClause` composition to avoid country-specific logic.
- Updated unit tests in `test/controllers/job.test.ts` and `test/middleware/inputValidators.test.ts` to reflect the new location clause strings and the removal of currency test cases.

### Testing

- Ran backend unit tests including `buildLocationWhere` suite and `useFilters` suite; all tests passed.
- Verified the updated `job.test.ts` and `inputValidators.test.ts` expectations reflect the new SQL clause strings and removed currency validations, and they succeeded under the test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c38023c508333bdc7298b3cee2131)